### PR TITLE
Live-Example Component Support .md Files

### DIFF
--- a/addon/components/docs-demo/x-live-example/component.js
+++ b/addon/components/docs-demo/x-live-example/component.js
@@ -10,7 +10,10 @@ export default Ember.Component.extend({
 
     // Set initial template from snippet
     let name = this.get('name');
-    let rawTemplate = snippets[`${name}.hbs`];
+
+    // We support either .hbs snippets or .md
+    let rawTemplate = snippets[`${name}.hbs`] || snippets[`${name}.md`];
+
     this.set('rawTemplate', this._unindent(rawTemplate));
 
     this.compileTemplate();


### PR DESCRIPTION
Finally a much smaller PR!

I am writing all of my docs using markdown, and one thing I noticed is that my live-example snippets weren't being shown. 

The first reason is that ember-code-snippet doesn't look for snippets in .md files :( 
https://github.com/ef4/ember-code-snippet/pull/41

The second reason is that the live-example component only looks for snippets generated with a `.hbs` extension. This PR is to address that.

So I'm just being a madonna here and really wanting to use markdown for my docs, but if I just switch over to .hbs I can literally finish writing v1 of my docs and it's great! 