### PR TITLE
Magic attributes for markdown code snippets?

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ module.exports = {
 
     includer.options.snippetSearchPaths = includer.options.snippetSearchPaths || ['tests/dummy/app'];
     includer.options.snippetRegexes = Object.assign({}, {
-      begin: /{{#(?:docs-snippet|demo.example|demo.live-example)\sname=(?:"|')(\S+)(?:"|')/,
-      end: /{{\/(?:docs-snippet|demo.example|demo.live-example)}}/,
+      begin: /(?:{{#(?:docs-snippet|demo.example|demo.live-example)\s+|```\w+?\|)name=(?:"|')(\S+?)(?:"|')/,
+      end: /(?:{{\/(?:docs-snippet|demo.example|demo.live-example)}}|```)/,
     }, includer.options.snippetRegexes);
 
     let importer = findImporter(this);

--- a/lib/preprocessors/markdown-template-compiler.js
+++ b/lib/preprocessors/markdown-template-compiler.js
@@ -10,7 +10,8 @@ module.exports = class MarkdownTemplateCompiler {
   }
 
   toTree(tree) {
-    let compiled = stew.map(tree, `**/*.{${this.ext}}`, string => compileMarkdown(string, {
+    let compiled = stew.map(tree, `**/*.{${this.ext}}`, (string, file) => compileMarkdown(string, {
+      file,
       targetHandlebars: true
     }));
 

--- a/lib/utils/compile-doc-descriptions.js
+++ b/lib/utils/compile-doc-descriptions.js
@@ -4,19 +4,19 @@ const compileMarkdown = require('./compile-markdown');
 
 module.exports = function compileDescriptions(docs) {
   for (let doc of docs) {
-    compileDescription([doc.attributes]);
-    compileDescription(doc.attributes.properties);
-    compileDescription(doc.attributes.methods);
-    compileDescription(doc.attributes.events);
+    compileDescription(doc, [doc.attributes]);
+    compileDescription(doc, doc.attributes.properties);
+    compileDescription(doc, doc.attributes.methods);
+    compileDescription(doc, doc.attributes.events);
   }
 }
 
-function compileDescription(objects) {
+function compileDescription(doc, objects) {
   if (!objects) { return; }
 
   for (let object of objects) {
     if (object.description) {
-      object.description = compileMarkdown(object.description);
+      object.description = compileMarkdown(object.description, { file: doc.attributes.file });
     }
   }
 }

--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -4,11 +4,10 @@ const marked = require('marked');
 const highlightjs = require('highlightjs');
 
 module.exports = function compileMarkdown(string, options) {
-  let config = { highlight };
-
-  if (options && options.targetHandlebars) {
-    config.renderer = new HBSRenderer();
-  }
+  let config = {
+    highlight,
+    renderer: new HBSRenderer(options),
+  };
 
   return `<div class="docs-md">${marked(string, config)}</div>`;
 };
@@ -22,14 +21,26 @@ function highlight(code, lang) {
 }
 
 class HBSRenderer extends marked.Renderer {
+  constructor(config) {
+    super();
+    this.config = config;
+  }
+
   // Escape curlies in code spans/blocks to avoid treating them as Handlebars
   codespan() {
     return this._escapeCurlies(super.codespan.apply(this, arguments));
   }
 
-  code() {
-    let code = this._escapeCurlies(super.code.apply(this, arguments));
-    return code.replace(/^<pre>/, '<pre class="docs-md__code">');
+  code(text, lang) {
+    if (lang && lang.indexOf('|') > -1) {
+      return this._buildDocsSnippetInvocation(text, lang);
+    } else {
+      let code = super.code.apply(this, arguments);
+      if (this.config.targetHandlebars) {
+        code = this._escapeCurlies(code);
+      }
+      return code.replace(/^<pre>/, '<pre class="docs-md__code">');
+    }
   }
 
   // Unescape quotes in text, as they may be part of a Handlebars statement
@@ -43,5 +54,35 @@ class HBSRenderer extends marked.Renderer {
     return string
       .replace(/{{/g, '&#123;&#123;')
       .replace(/}}/g, '&#125;&#125;');
+  }
+
+  // Convert code blocks like ```js|name='foo'|attr='bar'
+  // into {{docs-snippet language='js' name='foo' attr='bar'}}
+  _buildDocsSnippetInvocation(text, lang) {
+    if (!this.config.targetHandlebars) {
+      throw new Error(`${this.config.file}: Custom code snippet attributes aren't supported in doc comments.`);
+    }
+
+    let pipeIndex = lang.indexOf('|');
+    let componentProps = this._parseAttrs(lang.slice(pipeIndex + 1));
+    return `{{docs-snippet language='${lang.slice(0, pipeIndex)}' ${componentProps}}}`;
+  }
+
+  _parseAttrs(string) {
+    let regex = /(.+?)=('|")?(.*?)(?:\2)(?:\||$)/g;
+    let attrs = [];
+
+    let match;
+    while ((match = regex.exec(string))) {
+      let key = match[1];
+      let quote = match[2];
+      let value = match[3];
+      if (key === 'name') {
+        value += '.md';
+      }
+
+      attrs.push(`${key}=${quote}${value}${quote}`);
+    }
+    return attrs.join(' ');
   }
 }

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,5 +1,4 @@
 {{! BEGIN-SNIPPET docs-demo-application-template }}
-{{! // tests/dummy/app/templates/application.hbs }}
 {{docs-navbar logo='ember-cli' name='AddonDocs'}}
 
 {{outlet}}

--- a/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/quickstart/template.md
@@ -10,8 +10,7 @@ This quickstart guide will get you going with a docs site for your brand new add
 
 2. **Add the docs route.** Open `tests/dummy/app/router.js` and add a route named `docs`. Go ahead and make it nested, since this is where you'll be defining additional documentation pages.
 
-  ```js
-  // tests/dummy/app/router.js
+  ```js|name='quickstart-router'|title='tests/dummy/app/router.js'
   this.route('docs', function() {
     this.route('api', function() {
       this.route('class', { path: '/:class_id' });
@@ -21,12 +20,11 @@ This quickstart guide will get you going with a docs site for your brand new add
 
 3. **Create your app skeleton.** Open your application template and add the DocsNavbar component, customizing its properties for your project. You can also add the global keyboard shortcuts component (use `?` to show the help window). Here's our application template:
 
-  {{docs-snippet name="docs-demo-application-template.hbs"}}
+  {{docs-snippet name="docs-demo-application-template.hbs" title="tests/dummy/app/templates/application.hbs"}}
 
 4. **Create your docs skeleton.** Create a template for the `docs` route and add the DocsViewer component.
 
-  ```hbs
-  {{! tests/dummy/app/pods/docs/template.hbs }}
+  ```hbs|name='quickstart-docs-skeleton'|title='tests/dummy/app/pods/docs/template.hbs'
   {{#docs-viewer as |viewer|}}
 
     {{#viewer.nav as |nav|}}
@@ -46,8 +44,7 @@ This quickstart guide will get you going with a docs site for your brand new add
 
 5. **Fill out the index of your docs page.** We called it Overview but you can call it whatever you want. Since Addon Docs supports markdown templates out of the box, we can make this a Markdown file.
 
-  ```md
-  <!-- tests/dummy/app/templates/docs/index.md -->
+  ```md|name='quickstart-index'|title='tests/dummy/app/templates/docs/index.md'
   # Overview
 
   This is my new addon, and it rocks!
@@ -55,15 +52,13 @@ This quickstart guide will get you going with a docs site for your brand new add
 
 6. **Add a 404 route.** Add a route to the end of your router and create an associated template.
 
-  ```js
-  // tests/dummy/app/router.js
+  ```js|name='quickstart-not-found-route'|title='tests/dummy/app/router.js'
   this.route('not-found', { path: '/*path' });
   ```
 
   <br />
 
-  ```hbs
-  {{! tests/dummy/app/templates/not-found.hbs  }}
+  ```hbs|name='quickstart-not-found-template'|title='tests/dummy/app/templates/not-found.hbs'
   <div class="docs-container">
     <h1>Not found</h1>
     <p>This page doesn't exist. {{#link-to 'index'}}Head home?{{/link-to}}</p>
@@ -71,8 +66,7 @@ This quickstart guide will get you going with a docs site for your brand new add
   ```
 8. **Add more docs pages.** It's up to you how to structure your docs - use the Snippet, Viewer and Demo components to help you write your documentation. Let's add another page to ours: we'll add the route, link to our docs viewer, and the actual template.
 
-  ```js
-  // tests/dummy/app/router.js
+  ```js|name='quickstart-more-docs-pages'|title='tests/dummy/app/route.js'
   this.route('docs', function() {
     this.route('installation');
   });
@@ -80,8 +74,7 @@ This quickstart guide will get you going with a docs site for your brand new add
 
   <br />
 
-  ```hbs
-  {{! tests/dummy/app/templates/docs.hbs }}
+  ```hbs|name='quickstart-navigation'|title='tests/dummy/app/templates/docs.hbs'
   {{#viewer.nav as |nav|}}
     {{nav.item 'Installation' 'docs.installation'}}
   {{/viewer.nav}}
@@ -89,8 +82,7 @@ This quickstart guide will get you going with a docs site for your brand new add
 
   <br />
 
-  ```md
-  <!-- tests/dummy/app/templates/docs/installation.md -->
+  ```md|name='quickstart-installation'|title='tests/dummy/app/templates/docs/installation.md'
   # Installation
 
   To install My Addon, run...


### PR DESCRIPTION
@samselikoff I wanted to get your take on this idea — I added support for a `title` property on `{{docs-snippet}}` to help eliminate the need for all the leading comments describing what file the snippet is tied to, so for instance this:

```hbs
{{#code-snippet name='foo'}}
  {{! app/templates/components/my-component.hbs }}
  ...
{{/code-snippet}}
```

Can become this:

```hbs
{{#code-snippet name='foo' title='app/templates/components/my-component.hbs'}}
  ...
{{/code-snippet}}
```

Similar to how things are set up in the [Ember guides](https://guides.emberjs.com/v2.18.0/components/defining-a-component/).

That much is landed, but the problem I ran into is that this doesn't actually help Markdown code snippets, which we have a ton of e.g. in `quickstart/template.md`. The idea I had was to allow users to do something like this, and translate it into an actual invocation of the `{{docs-snippet}}` component:

```
```js|name='my-snippet'|title='app/controllers/my-controller.js'
```

Does the convenience of being able to do this over just manually invoking `{{docs-snippet}}` in your markdown seem worth the mental overhead of having yet another way to insert a code snippet? Note also that this won't work in API docs, since those are never processed as HBS templates, just straight Markdown --> HTML.