### PR TITLE
Skips non existing paths when exporting addon to app

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,11 @@ class AutoExportAddonToApp extends Plugin {
 
     // Non-pods modules (slightly different logic)
     [ 'adapters', 'controllers', 'models', 'routes', 'services', 'transitions' ].forEach(moduleType => {
-      let addonFiles = walkSync(path.join(addonPath, moduleType), { directories: false });
+      let addonFullPath = path.join(addonPath, moduleType);
+      if (!fs.existsSync(addonFullPath)) {
+        return;
+      }
+      let addonFiles = walkSync(addonFullPath, { directories: false });
 
       addonFiles.forEach(addonFile => {
         let module = addonFile.replace('.js', '');


### PR DESCRIPTION
We have discovered that exporting addon to app breaks
the build when the expected folders do not exist.

This PR simply checks that a folder exists before processing its contents.