### PR TITLE
Resolves paths correctly in treeForApp

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,12 +117,7 @@ module.exports = {
   treeForApp(app) {
     let trees = [ app ];
 
-    let addonPath;
-    if (this.project.name() === this.name) {
-      addonPath = this.project.root;
-    } else {
-      addonPath = this.project.findAddonByName(this.name).root;
-    }
+    let addonPath = this.project.findAddonByName(this.name).root;
     let addonTree = new Funnel(path.join(addonPath, 'addon'), {
       include: ['**/*.js']
     });

--- a/index.js
+++ b/index.js
@@ -117,11 +117,15 @@ module.exports = {
   treeForApp(app) {
     let trees = [ app ];
 
-    let addonPath = path.join(this.project.root, 'addon');
-    let addonTree = new Funnel(addonPath, {
+    let addonPath;
+    if (this.project.name() === this.name) {
+      addonPath = this.project.root;
+    } else {
+      addonPath = this.project.findAddonByName(this.name).root;
+    }
+    let addonTree = new Funnel(path.join(addonPath, 'addon'), {
       include: ['**/*.js']
     });
-
     let autoExportedAddonTree = new AutoExportAddonToApp([ addonTree ]);
     trees.push(autoExportedAddonTree);
 


### PR DESCRIPTION
When building the documentation for an addon with ember-cli-addon-docs,
the paths to ember-cli-addon-docs do not resolve correctly.