### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ notifications:
   email: false
 
 stages:
-  - test
-  - additional tests
+  - locked dependencies
+  - floating dependencies
   - versioned tests
   - deploy
 
@@ -43,14 +43,19 @@ jobs:
   fail_fast: true
 
   include:
-    - stage: test
-      env: NAME=test
-      script: yarn test
+    - stage: locked dependencies
+      env: NAME=browser tests
+      script: yarn test:browser
+    - env: NAME=node tests
+      script: yarn test:node
 
-    - stage: additional tests
-      env: NAME=floating dependencies
+    - stage: floating dependencies
+      env: NAME=browser tests
       install: yarn install --no-lockfile --non-interactive
-      script: yarn test
+      script: yarn test:browser
+    - env: NAME=node tests
+      install: yarn install --no-lockfile --non-interactive
+      script: yarn test:node
 
     - stage: versioned tests
       env: EMBER_TRY_SCENARIO=ember-lts-2.12
@@ -58,7 +63,6 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default
 
     - stage: deploy
       if: (branch = master OR tag IS present) AND type = push

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "ember try:each",
-    "test:node": "qunit tests-node"
+    "test:node": "qunit tests-node",
+    "test:browser": "ember test"
   },
   "dependencies": {
     "@glimmer/syntax": "^0.30.5",


### PR DESCRIPTION
I took a look at our Travis config, and it turned out we're still running all the ember-try scenarios in each of the first two stages because `yarn test` aliases `ember try:each`. This update:
 - updates the locked/floating dependencies phases to only run the test suite a single time
 - runs the node test suite for each of those (before it was being caught because there's an ember-try scenario for it, but that's not really the ideal way to manage it)
 - removes the `ember-default` try scenario from the versioned tests stage, since that should be equivalent to our 'floating dependencies' run

Before: [~33 minutes](https://travis-ci.org/ember-learn/ember-cli-addon-docs/builds/347354105) of wall clock time
After: [~14 minutes](https://travis-ci.org/ember-learn/ember-cli-addon-docs/builds/348084778) of wall clock time