### PR TITLE
[feat] API filtering

### DIFF
--- a/addon/components/api/x-class/component.js
+++ b/addon/components/api/x-class/component.js
@@ -1,19 +1,35 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { capitalize } from '@ember/string';
+import { memberFilter }  from '../../../utils/computed';
 
 import layout from './template';
 
 export default Component.extend({
   layout,
 
+  showInherited: false,
+  showProtected: false,
+  showPrivate: false,
+  showDeprecated: false,
+
+  accessors: memberFilter('class', 'accessors'),
+  methods: memberFilter('class', 'methods'),
+  fields: memberFilter('class', 'fields'),
+
   hasContents: computed('class', {
     get() {
       let klass = this.get('class');
 
-      return klass.get('constructors.length') > 0
-        || klass.get('fields.length') > 0
-        || klass.get('accessors.length') > 0
-        || klass.get('methods.length') > 0;
+      return klass.get('allFields.length') > 0
+        || klass.get('allAccessors.length') > 0
+        || klass.get('allMethods.length') > 0;
     }
-  })
+  }),
+
+  actions: {
+    updateFilter(filter, { target: { checked } }) {
+      this.set(`show${capitalize(filter)}`, checked);
+    }
+  }
 });

--- a/addon/components/api/x-class/template.hbs
+++ b/addon/components/api/x-class/template.hbs
@@ -6,11 +6,20 @@
 {{#if hasContents}}
   <div class="class-contents">
     {{api/x-index
+      options=(hash
+        inherited=inherited
+        protected=protected
+        private=private
+        deprecated=deprecated
+      )
+
+      onOptionToggle=(action 'updateFilter')
+
       sections=(hash
-        constructors=class.constructors
-        fields=class.fields
-        accessors=class.accessors
-        methods=class.methods
+        constructors=constructors
+        fields=fields
+        accessors=accessors
+        methods=methods
       )
     }}
 

--- a/addon/components/api/x-component/component.js
+++ b/addon/components/api/x-component/component.js
@@ -1,21 +1,42 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { capitalize } from '@ember/string';
+import { memberFilter }  from '../../../utils/computed';
 
 import layout from './template';
 
 export default Component.extend({
   layout,
 
+  showInherited: false,
+  showInternal: false,
+  showProtected: false,
+  showPrivate: false,
+  showDeprecated: false,
+
+  yields: alias('component.overloadedYields'),
+
+  arguments: memberFilter('component', 'arguments'),
+  accessors: memberFilter('component', 'accessors'),
+  methods: memberFilter('component', 'methods'),
+  fields: memberFilter('component', 'fields'),
+
   hasContents: computed('component', {
     get() {
       let component = this.get('component');
 
-      return component.get('constructors.length') > 0
-        || component.get('yields.length') > 0
+      return component.get('overloadedYields.length') > 0
         || component.get('arguments.length') > 0
         || component.get('fields.length') > 0
         || component.get('accessors.length') > 0
         || component.get('methods.length') > 0;
     }
-  })
+  }),
+
+  actions: {
+    updateFilter(filter, { target: { checked } }) {
+      this.set(`show${capitalize(filter)}`, checked);
+    }
+  }
 });

--- a/addon/components/api/x-component/template.hbs
+++ b/addon/components/api/x-component/template.hbs
@@ -6,24 +6,34 @@
 {{#if hasContents}}
   <div class="class-contents">
     {{api/x-index
+      options=(hash
+        inherited=(hash shouldShow=component.hasInherited value=showInherited)
+        internal=(hash shouldShow=component.hasInternal value=showInternal)
+        protected=(hash shouldShow=component.hasProtected value=showProtected)
+        private=(hash shouldShow=component.hasPrivate value=showPrivate)
+        deprecated=(hash shouldShow=component.hasDeprecated value=showDeprecated)
+      )
+
+      onOptionToggle=(action 'updateFilter')
+
       sections=(hash
-        constructors=component.constructors
-        yields=component.yields
-        arguments=component.arguments
-        fields=component.fields
-        accessors=component.accessors
-        methods=component.methods
+        constructors=constructors
+        yields=yields
+        arguments=arguments
+        fields=fields
+        accessors=accessors
+        methods=methods
       )
     }}
 
     {{api/x-sections
       sections=(hash
-        constructors=component.constructors
-        yields=component.yields
-        arguments=component.arguments
-        fields=component.fields
-        accessors=component.accessors
-        methods=component.methods
+        constructors=constructors
+        yields=yields
+        arguments=arguments
+        fields=fields
+        accessors=accessors
+        methods=methods
       )
     }}
   </div>

--- a/addon/components/api/x-index/style.scss
+++ b/addon/components/api/x-index/style.scss
@@ -1,5 +1,5 @@
 .class-index {
-  width: 200px;
+  flex: 0 0 200px;
   padding: 0 20px;
 
   font-size: 0.85em;

--- a/addon/components/api/x-index/template.hbs
+++ b/addon/components/api/x-index/template.hbs
@@ -1,6 +1,20 @@
 <div class="class-index__sticky">
   <h2>Index</h2>
 
+  <ul>
+    {{#each-in options as |key option|}}
+      {{#if option.shouldShow}}
+        <li>
+          <label>
+            <input type="checkbox" checked={{option.value}} onclick={{action onOptionToggle key}}>
+
+            {{capitalize key}}
+          </label>
+        </li>
+      {{/if}}
+    {{/each-in}}
+  </ul>
+
   {{#each-in sections as |section items|}}
     {{#if items}}
       <h3>{{capitalize section}}</h3>

--- a/addon/helpers/type-signature.js
+++ b/addon/helpers/type-signature.js
@@ -42,6 +42,14 @@ export function typeSignature([typed]) {
     signature = functionSignature(typed);
   }
 
+  if (typed.isStatic) {
+    signature = `static ${signature}`;
+  }
+
+  if (typed.access === 'private' || typed.access === 'protected') {
+    signature = `${typed.access} ${signature}`;
+  }
+
   return htmlSafe(signature);
 }
 

--- a/addon/models/class.js
+++ b/addon/models/class.js
@@ -1,4 +1,10 @@
 import DS from 'ember-data';
+import {
+  filterBy,
+  or,
+  union
+} from '@ember/object/computed';
+import { memberUnion, hasMemberType } from '../utils/computed';
 
 const { attr, belongsTo } = DS;
 
@@ -17,5 +23,61 @@ export default DS.Model.extend({
   accessors: attr(),
   methods: attr(),
   fields: attr(),
-  tags: attr()
+  tags: attr(),
+
+  publicAccessors: filterBy('accessors', 'access', 'public'),
+  publicMethods: filterBy('methods', 'access', 'public'),
+  publicFields: filterBy('fields', 'access', 'public'),
+
+  privateAccessors: filterBy('accessors', 'access', 'private'),
+  privateMethods: filterBy('methods', 'access', 'private'),
+  privateFields: filterBy('fields', 'access', 'private'),
+
+  protectedAccessors: filterBy('accessors', 'access', 'protected'),
+  protectedMethods: filterBy('methods', 'access', 'protected'),
+  protectedFields: filterBy('fields', 'access', 'protected'),
+
+  allPublicAccessors: memberUnion('parentClass.allPublicAccessors', 'publicAccessors'),
+  allPublicMethods: memberUnion('parentClass.allPublicMethods', 'publicMethods'),
+  allPublicFields: memberUnion('parentClass.allPublicFields', 'publicFields'),
+
+  allPrivateAccessors: memberUnion('parentClass.allPrivateAccessors', 'privateAccessors'),
+  allPrivateMethods: memberUnion('parentClass.allPrivateMethods', 'privateMethods'),
+  allPrivateFields: memberUnion('parentClass.allPrivateFields', 'privateFields'),
+
+  allProtectedAccessors: memberUnion('parentClass.allProtectedAccessors', 'protectedAccessors'),
+  allProtectedMethods: memberUnion('parentClass.allProtectedMethods', 'protectedMethods'),
+  allProtectedFields: memberUnion('parentClass.allProtectedFields', 'protectedFields'),
+
+  allAccessors: union('allPublicAccessors', 'allPrivateAccessors', 'allProtectedAccessors'),
+  allMethods: union('allPublicMethods', 'allPrivateMethods', 'allProtectedMethods'),
+  allFields: union('allPublicFields', 'allPrivateFields', 'allProtectedFields'),
+
+  hasInherited: or(
+    'parentClass.allAccessors.length',
+    'parentClass.allMethods.length',
+    'parentClass.allFields.length'
+  ),
+
+  hasPrivate: or(
+    'allPrivateAccessors.length',
+    'allPrivateMethods.length',
+    'allPrivateFields.length'
+  ),
+
+  hasProtected: or(
+    'allProtectedAccessors.length',
+    'allProtectedMethods.length',
+    'allProtectedFields.length'
+  ),
+
+  hasDeprecated: hasMemberType(
+    'allFields',
+    'allAccessors',
+    'allMethods',
+
+    function(member) {
+      return member.tags && member.tags.find(t => t.name === 'deprecated');
+    }
+  )
 });

--- a/addon/models/component.js
+++ b/addon/models/component.js
@@ -1,5 +1,8 @@
 import DS from 'ember-data';
+import { filterBy, or } from '@ember/object/computed';
+
 import Class from './class';
+import { memberUnion, hasMemberType } from '../utils/computed';
 
 const { attr } = DS;
 
@@ -7,5 +10,56 @@ export default Class.extend({
   isComponent: true,
 
   yields: attr(),
-  arguments: attr()
+  arguments: attr(),
+
+  overloadedYields: or('yields', 'inheritedYields'),
+
+  publicArguments: filterBy('arguments', 'access', 'public'),
+  privateArguments: filterBy('arguments', 'access', 'private'),
+  protectedArguments: filterBy('arguments', 'access', 'protected'),
+
+  allPublicArguments: memberUnion('parentClass.allPublicArguments', 'publicArguments'),
+  allPrivateArguments: memberUnion('parentClass.allPrivateArguments', 'privateArguments'),
+  allProtectedArguments: memberUnion('parentClass.allProtectedArguments', 'protectedArguments'),
+
+  allArguments: memberUnion('parentClass.allArguments', 'arguments'),
+
+  hasInherited: or(
+    'parentClass.overloadedYields.length',
+    'parentClass.allArguments.length',
+    'parentClass.allAccessors.length',
+    'parentClass.allMethods.length',
+    'parentClass.allFields.length'
+  ),
+
+  hasInternal: or(
+    'allAccessors.length',
+    'allMethods.length',
+    'allFields.length'
+  ),
+
+  hasPrivate: or(
+    'allPrivateAccessors.length',
+    'allPrivateArguments.length',
+    'allPrivateMethods.length',
+    'allPrivateFields.length'
+  ),
+
+  hasProtected: or(
+    'allProtectedAccessors.length',
+    'allProtectedArguments.length',
+    'allProtectedMethods.length',
+    'allProtectedFields.length'
+  ),
+
+  hasDeprecated: hasMemberType(
+    'allAccessors',
+    'allArguments',
+    'allMethods',
+    'allFields',
+
+    function(member) {
+      return member.tags && member.tags.find(t => t.name === 'deprecated');
+    }
+  )
 });

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -1,0 +1,113 @@
+import { computed } from '@ember/object';
+import { capitalize } from '@ember/string';
+
+/**
+  @hide
+*/
+export function memberUnion(parentMembersKey, childMembersKey) {
+  return computed(`${parentMembersKey}.[]`, `${childMembersKey}.[]`, function() {
+    let parentMembers = this.get(parentMembersKey);
+    let childMembers = this.get(childMembersKey);
+
+    if (!parentMembers) {
+      return childMembers;
+    }
+
+    let union = {};
+
+    for (let member of parentMembers) {
+      union[member.name] = member;
+    }
+
+    for (let member of childMembers) {
+      union[member.name] = member;
+    }
+
+    return Object.values(union);
+  });
+}
+
+function memberSort(a, b) {
+  if (a.isStatic && !b.isStatic) {
+    return -1;
+  } else if (b.isStatic && !a.isStatic) {
+    return 1;
+  }
+
+  if (
+    a.access === 'public' && b.access !== 'public'
+    || b.access === 'private' && a.access !== 'private'
+  ) {
+    return -1;
+  } else if (
+    a.access === 'private' && b.access !== 'private'
+    || b.access === 'public' && a.access !== 'public') {
+    return 1;
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
+/**
+  @hide
+*/
+export function memberFilter(classKey, memberType) {
+  return computed(
+    classKey,
+    'showInherited',
+    'showInternal',
+    'showProtected',
+    'showPrivate',
+    'showDeprecated',
+    function() {
+      let klass = this.get(classKey);
+      let showInternal = this.get('showInternal');
+      let showInherited = this.get('showInherited');
+      let showProtected = this.get('showProtected');
+      let showPrivate = this.get('showPrivate');
+      let showDeprecated = this.get('showDeprecated');
+
+      if (showInternal === false && memberType !== 'arguments') {
+        return [];
+      }
+
+      let capitalKey = capitalize(memberType);
+
+      let members = showInherited ? klass.get(`allPublic${capitalKey}`) : klass.get(`public${capitalKey}`);
+      let privateMembers = showInherited ? klass.get(`allPrivate${capitalKey}`) : klass.get(`private${capitalKey}`);
+      let protectedMembers = showInherited ? klass.get(`allProtected${capitalKey}`) : klass.get(`protected${capitalKey}`);
+
+      if (showPrivate) {
+        members.push(...privateMembers);
+      }
+
+      if (showProtected) {
+        members.push(...protectedMembers);
+      }
+
+      if (!showDeprecated) {
+        members = members.filter((m) => {
+          return !m.tags || !m.tags.find(t => t.name === 'deprecated');
+        });
+      }
+
+      return members.sort(memberSort);
+    }
+  );
+}
+
+/**
+  @hide
+*/
+export function hasMemberType(...memberKeys) {
+  let filter = memberKeys.pop();
+
+  return computed(...memberKeys.map(k => `${k}.[]`), {
+    get() {
+      return memberKeys.some((memberKey) => {
+        return this.get(memberKey).some((member) => filter(member, memberKey));
+      });
+    }
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.18.1",
     "ember-cli-addon-docs-esdoc": "^0.1.0",
-    "ember-cli-addon-docs-yuidoc": "^0.1.0",
+    "ember-cli-addon-docs-yuidoc": "^0.1.1",
     "ember-cli-dependency-checker": "^2.1.0",
     "ember-cli-deploy": "^1.0.2",
     "ember-cli-deploy-build": "^1.1.1",

--- a/sandbox/app/components/esdoc-component.js
+++ b/sandbox/app/components/esdoc-component.js
@@ -37,6 +37,16 @@ export default class ESDocComponent extends Component {
   onEvent;
 
   /**
+    An awesome static value
+  */
+  static isESDocComponent = true;
+
+  /**
+    PRIVATE DO NOT TOUCH
+  */
+  _privateField = 123;
+
+  /**
     The best method ever made, anywhere.
     @param {Object} features the features of the user
     @param {String} name the name of the user

--- a/sandbox/app/components/yuidoc-component.js
+++ b/sandbox/app/components/yuidoc-component.js
@@ -12,7 +12,29 @@ import Component from '@ember/component';
   @class YUIDocComponent
   @public
 */
-export default Component.extend({
+let YUIDocComponent = Component.extend({
+  /**
+    The count
+    @argument count
+    @type number
+  */
+ count: 0,
+
+  /**
+    An action that sends on events
+    @argument onEvent
+    @type Action
+  */
+  onEvent: null,
+
+  /**
+    PRIVATE DO NOT TOUCH
+
+    @field _privateField
+    @private
+    @type number
+  */
+  _privateField: 123,
 
   /**
     The best method ever made, anywhere.
@@ -27,3 +49,21 @@ export default Component.extend({
   }
 
 });
+
+YUIDocComponent.reopenClass({
+  /**
+    An awesome static value
+
+    @field isYUIDocComponent
+    @static
+    @type boolean
+  */
+  isYUIDocComponent: true
+});
+
+/**
+  ESDoc is double documenting this export, so hide the second export.
+
+  @hide
+*/
+export default YUIDocComponent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,9 +2735,9 @@ ember-cli-addon-docs-esdoc@^0.1.0:
     tmp "^0.0.33"
     walk-sync "^0.3.2"
 
-ember-cli-addon-docs-yuidoc@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-addon-docs-yuidoc/-/ember-cli-addon-docs-yuidoc-0.1.0.tgz#e08f0792d97148cb2f424d30a3fd165717cb03ef"
+ember-cli-addon-docs-yuidoc@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-addon-docs-yuidoc/-/ember-cli-addon-docs-yuidoc-0.1.1.tgz#4c74a02839ca23c0a29d5677a5da5f7c310454e1"
   dependencies:
     broccoli-caching-writer "^3.0.3"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
This PR adds filtering of members for classes and components that allows
users to filter out private, protected, inherited, and deprecated
members. In the case of components, users can also filter out `internal`
properties - everything besides Yields and Arguments.

Filters only appear if there is something to filter, and by default
they are enabled (unchecked), so users should see the minimal public API
of the class.

The complexity of the filters is definitely not ideal, but at the moment
I'm unsure if pushing that complexity into the object model (e.g. by
adding `publicFields`, `privateFields`, `staticPublicFields`,
`staticPrivateFields`, etc directly to models) as part of the build step
will help much.

<img width="678" alt="screen shot 2018-03-13 at 5 49 05 pm" src="https://user-images.githubusercontent.com/685518/37377393-df5da5b2-26e6-11e8-8cd7-1e4f0a52d73a.png">
<img width="673" alt="screen shot 2018-03-13 at 5 49 00 pm" src="https://user-images.githubusercontent.com/685518/37377397-e096f6e0-26e6-11e8-9791-e2f2a1cd0ae0.png">
