### PR TITLE
[feat] Allow specifying a documenter

### DIFF
--- a/lib/broccoli/docs-filter.js
+++ b/lib/broccoli/docs-filter.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Filter = require('broccoli-persistent-filter');
+
+const documenterRegex = /\/\*+\s*@documenter ([a-zA-Z]+)\s*\*+\//;
+
+module.exports = class DocsFilter extends Filter {
+  constructor(inputNode, documenter) {
+    super(inputNode);
+
+    this.documenter = documenter;
+  }
+
+  processString(content) {
+    let match = content.match(documenterRegex);
+
+    if (match) {
+      if (match[1] === this.documenter) {
+        return content.replace(documenterRegex, '');
+      }
+
+      return '';
+    }
+
+    return content;
+  }
+}

--- a/lib/models/plugin-registry.js
+++ b/lib/models/plugin-registry.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const DocsFilter = require('../broccoli/docs-filter');
+
 function isPluginPack(addon) {
   return addon.pkg.keywords.indexOf('ember-cli-addon-docs-plugin-pack') !== -1;
 }
@@ -27,7 +29,7 @@ class PluginRegistry {
   createDocsGenerators(inputTree, options) {
     if (this._docsGenerators === null) {
       this._docsGenerators = this.plugins.map(p => p.createDocsGenerator(
-        inputTree,
+        new DocsFilter(inputTree, p.name.replace('ember-cli-addon-docs-', '')),
         options
       ));
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "broccoli-filter": "^1.2.4",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-persistent-filter": "^1.4.3",
     "broccoli-plugin": "^1.3.0",
     "broccoli-stew": "^1.5.0",
     "ember-ace": "^1.2.0",

--- a/sandbox/app/components/esdoc-component.js
+++ b/sandbox/app/components/esdoc-component.js
@@ -1,3 +1,5 @@
+/** @documenter esdoc */
+
 import Component from '@ember/component';
 import { action } from '@ember-decorators/object';
 import { argument } from '@ember-decorators/argument';

--- a/sandbox/app/components/yuidoc-component.js
+++ b/sandbox/app/components/yuidoc-component.js
@@ -1,3 +1,5 @@
+/** @documenter yuidoc */
+
 import Component from '@ember/component';
 
 /**
@@ -61,9 +63,4 @@ YUIDocComponent.reopenClass({
   isYUIDocComponent: true
 });
 
-/**
-  ESDoc is double documenting this export, so hide the second export.
-
-  @hide
-*/
 export default YUIDocComponent;


### PR DESCRIPTION
Currently we're having lots of things be double documented
by ESDoc, which is making it really hard to debug issues.
This adds a quick option @documenter tag that'll filter
out files based on what they declare they _should_ be
documented by.