### PR TITLE
support for scoped packages

### DIFF
--- a/addon/components/docs-viewer/x-nav/component.js
+++ b/addon/components/docs-viewer/x-nav/component.js
@@ -20,11 +20,11 @@ export default Component.extend({
   addonLogo: computed(function() {
     let name = packageJson.name;
     let logo;
-    if (name.match(/^ember-cli/)) {
+    if (name.match(/ember-cli/)) {
       logo = 'ember-cli';
-    } else if (name.match(/^ember-data/)) {
+    } else if (name.match(/ember-data/)) {
       logo = 'ember-data';
-    } else if (name.match(/^ember/)) {
+    } else {
       logo = 'ember';
     }
 

--- a/lib/broccoli/docs-compiler.js
+++ b/lib/broccoli/docs-compiler.js
@@ -276,9 +276,9 @@ module.exports = class DocsCompiler extends CachingWriter {
       modules
     }
 
-    let baseDir = path.join(this.outputPath, 'docs');
+    let baseDir = path.join(this.outputPath, 'docs', name);
 
     fs.ensureDirSync(baseDir);
-    fs.writeJsonSync(path.join(baseDir, name + '.json'), Serializer.serialize('project', project));
+    fs.writeJsonSync(path.join(baseDir + '.json'), Serializer.serialize('project', project));
   }
 }


### PR DESCRIPTION
* Ensures that we can correctly create a nested directory in the event that a package's name is `@myscope/package-name`.  This was breaking because the `@myscope` directory wasn't being created before.
* Ensures that we don't rely on matching names to be at the start of a package's name to allow for a scope to be at the beginning

Fixes https://github.com/ember-learn/ember-cli-addon-docs/issues/46, but I'm honestly not 100% sure if this is the best approach.
Fixes #111