### PR TITLE
Stop including jquery and shims in the output

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,6 +12,7 @@ module.exports = function(defaults) {
 
   var app = new EmberAddon(defaults, {
     project,
+    vendorFiles: { 'jquery.js': null, 'app-shims.js': null },
     svgJar: {
       sourceDirs: [
         'public',


### PR DESCRIPTION
Before:
```
File sizes:
 - dist/assets/dummy-85b90b99235e74788ee6f2d9e1a8ae0f.js: 154.27 KB (33.92 KB gzipped)
 - dist/assets/vendor-5e6d3ca90736b58a05177e7786ece4f5.js: 1.67 MB (442.97 KB gzipped)
```

After:

```
File sizes:
 - dist/assets/dummy-85b90b99235e74788ee6f2d9e1a8ae0f.js: 154.27 KB (33.92 KB gzipped)
 - dist/assets/vendor-1ae6d4df0c293cba4de9787f665208aa.js: 1.58 MB (413.65 KB gzipped)
```

This saves 29,32KB after gzip.