### PR TITLE
Don't ship with `isDevelopingAddon: true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,6 @@ const DEFAULT_PROJECTS = {
 module.exports = {
   name: 'ember-cli-addon-docs',
 
-  isDevelopingAddon() {
-    return true;
-  },
-
   options: {
     ace: {
       modes: ['handlebars']


### PR DESCRIPTION
I don't think this is the root cause of #106, but it can't be helping. In general having this flag turned on in production is bad for performance because it opts the addon into things like linting that the host shouldn't be concerned with.