### PR TITLE
Clean up `logo` code

### DIFF
--- a/addon/components/docs-header/component.js
+++ b/addon/components/docs-header/component.js
@@ -33,7 +33,7 @@ export default Component.extend({
 
   packageJson: packageJson,
 
-  addonLogo: addonLogo(packageJson),
+  logo: addonLogo(packageJson),
 
   addonName: computed(function() {
     let name = packageJson.name;

--- a/addon/components/docs-header/component.js
+++ b/addon/components/docs-header/component.js
@@ -35,7 +35,7 @@ export default Component.extend({
 
   logo: addonLogo(packageJson),
 
-  addonName: computed(function() {
+  name: computed(function() {
     let name = packageJson.name;
     name = name.replace('ember-data-', '');
     name = name.replace('ember-cli-', '');

--- a/addon/components/docs-header/component.js
+++ b/addon/components/docs-header/component.js
@@ -3,6 +3,7 @@ import layout from './template';
 import config from 'dummy/config/environment';
 import { computed } from '@ember/object';
 import { classify } from '@ember/string';
+import { addonLogo } from 'ember-cli-addon-docs/utils/computed';
 
 const packageJson = config['ember-cli-addon-docs'].packageJson;
 
@@ -32,20 +33,7 @@ export default Component.extend({
 
   packageJson: packageJson,
 
-  addonLogo: computed(function() {
-    let name = packageJson.name;
-    let logo;
-
-    if (name.match('ember-cli-')) {
-      logo = 'ember-cli';
-    } else if (name.match('ember-data-')) {
-      logo = 'ember-data';
-    } else if (name.match('ember-data-')) {
-      logo = 'ember';
-    }
-
-    return logo;
-  }),
+  addonLogo: addonLogo(packageJson),
 
   addonName: computed(function() {
     let name = packageJson.name;

--- a/addon/components/docs-header/template.hbs
+++ b/addon/components/docs-header/template.hbs
@@ -7,7 +7,7 @@
             {{docs-logo logo=logo}}
           </div>
         {{/if}}
-        <span class='font-medium normal-case block -mt-2px'>{{addonName}}</span>
+        <span class='font-medium normal-case block -mt-2px'>{{name}}</span>
       </div>
     {{/docs-header/link}}
 

--- a/addon/components/docs-header/template.hbs
+++ b/addon/components/docs-header/template.hbs
@@ -4,7 +4,7 @@
       <div class="text-center text-xs">
         {{#if logo}}
           <div class='h-4 pb-1'>
-            {{docs-logo logo=addonLogo}}
+            {{docs-logo logo=logo}}
           </div>
         {{/if}}
         <span class='font-medium normal-case block -mt-2px'>{{addonName}}</span>

--- a/addon/components/docs-viewer/x-nav/component.js
+++ b/addon/components/docs-viewer/x-nav/component.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import layout from './template';
 import config from 'dummy/config/environment';
 import { classify } from '@ember/string';
+import { addonLogo } from 'ember-cli-addon-docs/utils/computed';
 
 const packageJson = config['ember-cli-addon-docs'].packageJson;
 
@@ -17,19 +18,7 @@ export default Component.extend({
   store: service(),
   packageJson,
 
-  addonLogo: computed(function() {
-    let name = packageJson.name;
-    let logo;
-    if (name.match(/ember-cli/)) {
-      logo = 'ember-cli';
-    } else if (name.match(/ember-data/)) {
-      logo = 'ember-data';
-    } else {
-      logo = 'ember';
-    }
-
-    return logo;
-  }),
+  addonLogo: addonLogo(packageJson),
 
   addonTitle: computed('addonLogo', function() {
     let logo = this.get('addonLogo');

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -111,3 +111,21 @@ export function hasMemberType(...memberKeys) {
   });
 }
 
+/**
+  @hide
+*/
+export function addonLogo(packageJson) {
+  return computed(function() {
+    let name = packageJson.name;
+    let logo;
+    if (name.match(/ember-cli/)) {
+      logo = 'ember-cli';
+    } else if (name.match(/ember-data/)) {
+      logo = 'ember-data';
+    } else {
+      logo = 'ember';
+    }
+
+    return logo;
+  });
+}


### PR DESCRIPTION
* Used in two places, on of which was broken. Split out into a separate function that both locations can import
* Only the `docs-header` used the `addonLogo` property, all other references to the same feature use `logo`. The documentation also used `logo` but the implementation was setting `addonLogo` and ignoring the provided `logo` property. Now it's all just `logo`