### PR TITLE
Avoid using an <a> without navigation

### DIFF
--- a/addon/components/docs-demo/template.hbs
+++ b/addon/components/docs-demo/template.hbs
@@ -9,16 +9,15 @@
   {{#if snippets}}
     <nav class="docs-demo__snippets-nav py-2 px-4 font-medium bg-grey-lighter tracking-tight">
       {{#each snippets as |snippet|}}
-        <a href='#' {{action 'selectSnippet' snippet}}
+        <button {{action 'selectSnippet' snippet}}
           class='
-            docs-demo__snippets-nav-item
-            mr-4 text-sm no-underline
+            mr-4 text-sm no-underline outline-none
             hover:text-grey-darkest
             {{if snippet.isActive 'text-grey-darkest' 'text-grey-dark'}}
           '
         >
           {{snippet.label}}
-        </a>
+        </button>
       {{/each}}
     </nav>
   {{/if}}

--- a/addon/tailwind/config/modules.css
+++ b/addon/tailwind/config/modules.css
@@ -139,6 +139,7 @@ pre {
 .overflow-momentum {
   -webkit-overflow-scrolling: touch;
 }
-.outline-none {
+.outline-none,
+.outline-none:focus {
   outline: none;
 }


### PR DESCRIPTION
Generally, `<a>` should be avoided with `href="#"` since it's not "semantically correct" to use a link when no navigation occurs. A `<button>` is better semantically. It looks the same, just without the navigation.