### PR TITLE
Fix template edit link

### DIFF
--- a/addon/components/docs-viewer/x-main/component.js
+++ b/addon/components/docs-viewer/x-main/component.js
@@ -35,8 +35,9 @@ export default Component.extend({
 
       return `${packageJson.repository}/edit/master/addon/components/${klass}/component.js`;
     } else {
-      let templatePath = `pods/${path}`;
-      let file = appFiles.find(file => file.match(`${templatePath}/template.(hbs|md)`));
+      let file = appFiles
+        .filter(file => file.match(/template.(hbs|md)/))
+        .find(file => file.match(path));
 
       return `${packageJson.repository}/edit/master/tests/dummy/app/${file}`;
     }

--- a/addon/components/docs-viewer/x-main/component.js
+++ b/addon/components/docs-viewer/x-main/component.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import layout from './template';
 import { computed } from '@ember/object';
 import appFiles from 'ember-cli-addon-docs/app-files';
-import { dasherize } from '@ember/string';
+import addonFiles from 'ember-cli-addon-docs/addon-files';
 import config from 'dummy/config/environment';
 import { getOwner } from '@ember/application';
 
@@ -23,17 +23,19 @@ export default Component.extend({
   editCurrentPageUrl: computed('router.currentRouteName', function() {
     let path = this.get('router.currentRouteName');
     if (!path) {
-      // `routing` doesn't exist for old ember versions via ember-try
+      // `router` doesn't exist for old ember versions via ember-try
       return;
     }
+
     path = path.replace(/\./g, '/');
 
-    if (path === 'docs/api/class') {
-      let params = getOwner(this).lookup('route:application').paramsFor('docs.api.class');
-      let klass = dasherize(params.class_id.replace(/-.+$/g, ''));
-      let path = `pods/${path}`;
+    if (path === 'docs/api/item') {
+      let { path } = getOwner(this).lookup('route:application').paramsFor('docs.api.item');
+      let file = addonFiles.find(f => f.match(path));
 
-      return `${packageJson.repository}/edit/master/addon/components/${klass}/component.js`;
+      if (file) {
+        return `${packageJson.repository}/edit/master/addon/${file}`;
+      }
     } else {
       let file = appFiles
         .filter(file => file.match(/template.(hbs|md)/))

--- a/index.js
+++ b/index.js
@@ -147,8 +147,9 @@ module.exports = {
 
   treeForAddon(tree) {
     let dummyAppFiles = new FindDummyAppFiles([ 'tests/dummy/app' ]);
+    let addonFiles = new FindAddonFiles([ 'addon' ]);
 
-    return this._super(new MergeTrees([ tree, dummyAppFiles ]));
+    return this._super(new MergeTrees([ tree, dummyAppFiles, addonFiles ]));
   },
 
   treeForVendor(vendor) {
@@ -277,6 +278,16 @@ class FindDummyAppFiles extends Plugin {
     let pathsString = JSON.stringify(paths);
 
     fs.writeFileSync(path.join(this.outputPath, 'app-files.js'), `export default ${pathsString};`);
+  }
+}
+
+class FindAddonFiles extends Plugin {
+  build() {
+    let addonPath = this.inputPaths[0];
+    let paths = walkSync(addonPath, { directories: false })
+    let pathsString = JSON.stringify(paths);
+
+    fs.writeFileSync(path.join(this.outputPath, 'addon-files.js'), `export default ${pathsString};`);
   }
 }
 


### PR DESCRIPTION
- More generic matching (removes assumption that the file is within the `pods` directory)
- Fixes some references to the original `docs.api.class` route and updates them to use `docs.api.item`