### PR TITLE
[bugfix][API] Prevent duplicate members from filters

### DIFF
--- a/addon/components/docs-demo/component.js
+++ b/addon/components/docs-demo/component.js
@@ -50,6 +50,7 @@ export default Component.extend({
     and whether or not it is active.
 
     @computed snippets
+    @private
     @type Array<Object>
     @readOnly
    */

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -67,15 +67,20 @@ export function memberFilter(classKey, memberType) {
       let showPrivate = this.get('showPrivate');
       let showDeprecated = this.get('showDeprecated');
 
+      let members = [];
+
       if (showInternal === false && memberType !== 'arguments') {
-        return [];
+        return members;
       }
 
       let capitalKey = capitalize(memberType);
 
-      let members = showInherited ? klass.get(`allPublic${capitalKey}`) : klass.get(`public${capitalKey}`);
+
+      let publicMembers = showInherited ? klass.get(`allPublic${capitalKey}`) : klass.get(`public${capitalKey}`);
       let privateMembers = showInherited ? klass.get(`allPrivate${capitalKey}`) : klass.get(`private${capitalKey}`);
       let protectedMembers = showInherited ? klass.get(`allProtected${capitalKey}`) : klass.get(`protected${capitalKey}`);
+
+      members.push(...publicMembers);
 
       if (showPrivate) {
         members.push(...privateMembers);


### PR DESCRIPTION
Duplicate members were being added directly to the public member array
on each toggle. This PR ensures that there is a new array created each
time the computed is run.

Closes #138 