### PR TITLE
Changes the way lookups are performed, using file path

### DIFF
--- a/addon/routes/docs/api/item.js
+++ b/addon/routes/docs/api/item.js
@@ -17,7 +17,7 @@ export default Route.extend({
         || module;
     } else {
       let modules = this.store.peekAll('module');
-      let matches = modules.filter(m => m.id.match(path));
+      let matches = modules.filter(m => (m.get('file') === `/${path}`));
       let module = matches[0];
 
       assert(`no modules match the path '${path}'`, matches.length > 0);


### PR DESCRIPTION
Addresses #94, this does an exact lookup of the module by `file` property, along with some formatting (rather than id). This allows similar-named modules (components specifically) to be listed without asserted errors about multiple modules. 

@pzuraq mentioned we need to look into why the model does the lookup this way currently (using String#match, see #149).
