### PR TITLE
fix(quickstart): index header should match the nav name

### DIFF
--- a/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/quickstart/template.md
@@ -53,7 +53,7 @@ of the box we will create two `.md` files (one for your docs `index` and one
 for the `usage` page).
 
   {{#docs-snippet name='quickstart-markdown-index.md' title='tests/dummy/app/templates/docs/index.md' language='markdown'}}
-    # Index
+    # Introduction
 
     This is my new addon, and it rocks!
   {{/docs-snippet}}


### PR DESCRIPTION
It's called 'Introduction' in the nav block above, so should probably match here as well.