### PR TITLE
Remove search focus shortcut

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/addon/components/docs-header/search-box/component.js
+++ b/addon/components/docs-header/search-box/component.js
@@ -15,12 +15,11 @@ export default Component.extend(EKMixin, {
     this.set('keyboardActivated', true);
   },
 
-  focusSearch: on(keyUp('Slash'), keyUp('KeyS'), function() {
+  focusSearch: on(keyUp('Slash'), function() {
     this.element.querySelector('input').focus();
   }),
 
   unfocusSearch: on(keyUp('Escape'), function() {
     this.get('on-input')(null);
   })
-
 });


### PR DESCRIPTION
This removes the shortcut "S" for focusing the search box. Also I added a `.prettierrc` file using your conventions.

This fixes issue #157 