### PR TITLE
update ember-cli-tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-sass": "7.1.3",
     "ember-cli-string-helpers": "^1.7.0",
-    "ember-cli-tailwind": "0.4.0",
+    "ember-cli-tailwind": "0.4.1",
     "ember-code-snippet": "^2.1.0",
     "ember-component-css": "^0.3.5",
     "ember-concurrency": "^0.8.16",


### PR DESCRIPTION
This should remove an ember-cli-babel related deprecation when building projects.