### PR TITLE
Fix missing cookies on XHR GET search-index.json

### DIFF
--- a/addon/services/docs-search.js
+++ b/addon/services/docs-search.js
@@ -72,7 +72,7 @@ export default Service.extend({
 
   loadSearchIndex() {
     if (!this._searchIndex) {
-      this._searchIndex = fetch(this.get('_indexURL'))
+      this._searchIndex = fetch(this.get('_indexURL'), { credentials: 'same-origin' })
         .then(res => res.json())
         .then(json => {
           return {


### PR DESCRIPTION
XHR request to fetch the search index, fails when done inside a protected domain that requires authentication (done with cookies). 