### PR TITLE
Remove keyboard shortcuts from default template

### DIFF
--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -13,7 +13,8 @@
 
   {{! BEGIN-SNIPPET docs-demo-application-template.hbs }}
   {{outlet}}
-
-  {{docs-keyboard-shortcuts}}
+  
+  {{!-- Optionally enable keyboard shortcuts --}}
+  {{!-- {{docs-keyboard-shortcuts}} --}}
   {{! END-SNIPPET }}
 </div>


### PR DESCRIPTION
Something that was tripping me up typing in an input was the keyboard shortcuts were automatically included in the `application.hbs` but specified as optional.