### PR TITLE
move latest to top-level URL

### DIFF
--- a/lib/deploy/plugin.js
+++ b/lib/deploy/plugin.js
@@ -38,7 +38,7 @@ module.exports = class AddonDocsDeployPlugin {
   }
 
   willUpload(context) {
-    let relativeBuildDestination = this._getVersionPath();
+    let relativeBuildDestination = path.join('versions', this._getVersionPath());
     let stagingDirectory = context.addonDocs.stagingDirectory;
     let fullBuildDestination = path.join(stagingDirectory, relativeBuildDestination);
 
@@ -65,7 +65,7 @@ module.exports = class AddonDocsDeployPlugin {
       fs.copySync(`${vendorDir}/index.html`, `${stagingDirectory}/index.html`);
     }
 
-    let segmentCount = this._getRootURL().split('/').length + 1;
+    let segmentCount = this._getRootURL().split('/').length;
     let redirectContents = fs.readFileSync(`${vendorDir}/404.html`, 'utf-8');
     redirectContents = redirectContents.replace(/\bADDON_DOCS_SEGMENT_COUNT\b/g, segmentCount);
     fs.writeFileSync(`${stagingDirectory}/404.html`, redirectContents);
@@ -113,10 +113,12 @@ module.exports = class AddonDocsDeployPlugin {
   _maybeUpdateLatest(context, stagingDirectory) {
     if (!this.userConfig.shouldUpdateLatest()) { return; }
 
-    let latestDir = this._getVersionPath('latest');
+    let latestDir = '';
     let fullPath = path.join(stagingDirectory, latestDir);
-    let deployVersion = this._latestDeployVersion();
-    return fs.remove(fullPath)
+    let deployVersion = this._latestDeployVersion();    
+    return filterDir(fullPath, 
+      relativeName => ['versions', 'versions.json', '404.html'].includes(relativeName)
+    )
       .then(() => fs.copy(context.distDir, fullPath))
       .then(() => this._updateIndexContents(context, stagingDirectory, latestDir, deployVersion));
   }
@@ -133,19 +135,19 @@ module.exports = class AddonDocsDeployPlugin {
   }
 
   _currentDeployVersion() {
-    let path = this._getVersionPath();
+    let curpath = path.join('versions', this._getVersionPath());
     let name = this.userConfig.getVersionName();
     let sha = this.userConfig.repoInfo.sha;
     let tag = this.userConfig.repoInfo.tag;
-    return { path, name, sha, tag };
+    return { path: curpath, name, sha, tag };
   }
 
   _latestDeployVersion() {
-    let path = this._getVersionPath('latest');
+    let curpath = '';
     let name = 'latest';
     let sha = this.userConfig.repoInfo.sha;
     let tag = this.userConfig.repoInfo.tag;
-    return { path, name, sha, tag };
+    return { path: curpath, name, sha, tag };
   }
 
   _inferRepoUrl(context) {
@@ -206,4 +208,14 @@ module.exports = class AddonDocsDeployPlugin {
 function git() {
   return execa('git', [].slice.call(arguments))
     .then((result) => result.stdout.trim());
+}
+
+function filterDir(dir, predicate) {
+  return fs.readdir(dir).then(files => {
+    return Promise.all(files.map(file => {
+      if (!predicate(file)){
+        return fs.remove(path.join(dir, file));
+      }
+    }));
+  })
 }

--- a/vendor/ember-cli-addon-docs/404.html
+++ b/vendor/ember-cli-addon-docs/404.html
@@ -26,6 +26,12 @@
       var l = window.location;
       var segments = l.pathname.split('/');
 
+      // If we're inside the special "versions" path, we want to load a versioned 
+      // child app, and those are two segments deeper than the top-level app.
+      if (segments[segmentCount+1] === "versions") {
+        segmentCount += 2;
+      }
+
       // Avoid an infinite loop if we try to direct to a location that doesn't exist
       if (!/^\?p=\/.*&q=.*/.test(l.search)) {
         l.replace(


### PR DESCRIPTION
This PR eliminates the need to redirect from `/` to `/latest` by deploying the latest version at the top level instead of under `/latest`, moving all other versions under a special `/versions` path (like `/versions/beta` or `/versions/v1.0.0`), and adapting the redirection logic to handle both cases (top-level app vs versioned which can be distinguished by the presence of the “versions” name immediately after the true root URL).

This is a breaking change for existing sites, which leads to some questions for discussion:

- Are people OK with making this new layout default, vs having a config option that would let existing sites stay as they are?
- Should we just do a major release and give manual upgrade instructions?
- Should we try to make an automatic upgrade (it’s hard in general because deployed versioned apps have already been rewritten for their current locations, and there is no reliable pattern to search and replace). 



