### PR TITLE
Eliminate free-floating 'latest' and 'master' references

### DIFF
--- a/addon/components/docs-header/component.js
+++ b/addon/components/docs-header/component.js
@@ -7,7 +7,7 @@ import { addonLogo } from 'ember-cli-addon-docs/utils/computed';
 import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
 
-const { projectName, projectHref } = config['ember-cli-addon-docs'];
+const { projectName, projectHref, latestVersionName } = config['ember-cli-addon-docs'];
 
 /**
   Render a header showing a link to your documentation, your project logo, a
@@ -36,6 +36,7 @@ export default Component.extend({
   projectVersion: service(),
 
   projectHref,
+  latestVersionName,
 
   didInsertElement() {
     this._super(...arguments);

--- a/addon/components/docs-header/template.hbs
+++ b/addon/components/docs-header/template.hbs
@@ -25,7 +25,7 @@
       {{#docs-header/link on-click=(action (toggle 'isShowingVersionSelector' this)) data-test-id='current-version'}}
         <span data-version-selector class='flex items-center'>
 
-          {{#if (or (eq currentVersion.name 'latest'))}}
+          {{#if (or (eq currentVersion.name latestVersionName))}}
             {{#if currentVersion.tag}}
               {{currentVersion.tag}}
             {{else}}

--- a/addon/components/docs-header/version-selector/component.js
+++ b/addon/components/docs-header/version-selector/component.js
@@ -3,9 +3,15 @@ import { inject as service } from '@ember/service';
 import layout from './template';
 import { sort } from '@ember/object/computed';
 import { reads } from '@ember/object/computed';
+import config from 'dummy/config/environment';
+
+const { latestVersionName, primaryBranch } = config['ember-cli-addon-docs'];
 
 export default Component.extend({
   layout,
+
+  latestVersionName,
+  primaryBranch,
 
   projectVersion: service(),
   'on-close'() {},
@@ -13,7 +19,7 @@ export default Component.extend({
   currentVersion: reads('projectVersion.currentVersion'),
 
   sortedVersions: sort('projectVersion.versions', function(a, b) {
-    if (['latest', 'master'].includes(a.name) || ['latest', 'master'].includes(b.name) ) {
+    if ([latestVersionName, primaryBranch].includes(a.name) || [latestVersionName, primaryBranch].includes(b.name) ) {
       return a.name > b.name;
     } else {
       return a.name < b.name;

--- a/addon/components/docs-header/version-selector/template.hbs
+++ b/addon/components/docs-header/version-selector/template.hbs
@@ -14,18 +14,18 @@
             {{/if}}
           </span>
           <span class='font-medium'>
-            {{if (eq version.name 'latest') 'Latest' version.name}}
+            {{if (eq version.name latestVersionName) 'Latest' version.name}}
           </span>
 
           <span class="ml-auto pl-8 flex items-center opacity-50">
-            {{#if (or (eq version.name 'latest') (eq version.name 'master'))}}
+            {{#if (or (eq version.name latestVersionName) (eq version.name primaryBranch))}}
               {{svg-jar (if version.tag 'git-tag' 'git-sha') height=16 width=16}}
             {{else}}
               {{svg-jar 'git-sha' height=16 width=16}}
             {{/if}}
 
             <span class='text-xs font-mono pl-1'>
-              {{#if (or (eq version.name 'latest') (eq version.name 'master'))}}
+              {{#if (or (eq version.name latestVersionName) (eq version.name primaryBranch))}}
                 {{#if version.tag}}
                   {{version.tag}}
                 {{else}}

--- a/addon/components/docs-viewer/x-main/component.js
+++ b/addon/components/docs-viewer/x-main/component.js
@@ -9,7 +9,7 @@ import { getOwner } from '@ember/application';
 
 import layout from './template';
 
-const projectHref = config['ember-cli-addon-docs'].projectHref;
+const { projectHref, primaryBranch } = config['ember-cli-addon-docs'];
 
 const tagToSize = { H2: 'xs', H3: 'xs' };
 const tagToIndent = { H2: '0', H3: '4' };
@@ -76,14 +76,14 @@ export default Component.extend({
       let file = addonFiles.find(f => f.match(path));
 
       if (file) {
-        return `${projectHref}/edit/master/addon/${file}`;
+        return `${projectHref}/edit/${primaryBranch}/addon/${file}`;
       }
     } else {
       let file = appFiles
         .filter(file => file.match(/template.(hbs|md)/))
         .find(file => file.match(path));
 
-      return `${projectHref}/edit/master/tests/dummy/app/${file}`;
+      return `${projectHref}/edit/${primaryBranch}/tests/dummy/app/${file}`;
     }
   })
 

--- a/addon/services/project-version.js
+++ b/addon/services/project-version.js
@@ -2,13 +2,16 @@ import Service, { inject as service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
+import config from 'dummy/config/environment';
+
+const { latestVersionName } = config['ember-cli-addon-docs'];
 
 export default Service.extend({
   docsFetch: service(),
 
   _loadAvailableVersions: task(function*() {
     let response = yield this.get('docsFetch').fetch({ url: `${this.get('root')}versions.json` }).response();
-    let json = yield response.ok ? response.json() : { latest: this.get('currentVersion') };
+    let json = yield response.ok ? response.json() : { [latestVersionName]: this.get('currentVersion') };
 
     this.set('versions', Object.keys(json).map(key => {
       let version = json[key];
@@ -38,7 +41,7 @@ export default Service.extend({
     // In development, this token won't have been replaced replaced
     if (currentVersion === 'ADDON_DOCS_DEPLOY_VERSION') {
       currentVersion = {
-        name: 'latest',
+        name: latestVersionName,
         tag: config.projectTag,
         path: '',
         sha: 'abcde'

--- a/blueprints/ember-cli-addon-docs/files/config/addon-docs.js
+++ b/blueprints/ember-cli-addon-docs/files/config/addon-docs.js
@@ -4,6 +4,6 @@
 const AddonDocsConfig = require('ember-cli-addon-docs/lib/config');
 
 module.exports = class extends AddonDocsConfig {
-  // See https://ember-learn.github.io/ember-cli-addon-docs/latest/docs/deploying
+  // See https://ember-learn.github.io/ember-cli-addon-docs/docs/deploying
   // for details on configuration you can override here.
 };

--- a/index.js
+++ b/index.js
@@ -9,8 +9,12 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app'); // eslint-disable-
 const Plugin = require('broccoli-plugin');
 const walkSync = require('walk-sync');
 
+const LATEST_VERSION_NAME = '-latest';
+
 module.exports = {
   name: 'ember-cli-addon-docs',
+
+  LATEST_VERSION_NAME,
 
   options: {
     nodeAssets: {
@@ -38,6 +42,7 @@ module.exports = {
   config(env, baseConfig) {
     let repo = this.parent.pkg.repository;
     let info = require('hosted-git-info').fromUrl(repo.url || repo);
+    let userConfig = this._readUserConfig();
 
     let config = {
       'ember-component-css': {
@@ -47,6 +52,8 @@ module.exports = {
         projectName: this.parent.pkg.name,
         projectTag: this.parent.pkg.version,
         projectHref: info && info.browse(),
+        primaryBranch: userConfig.getPrimaryBranch(),
+        latestVersionName: LATEST_VERSION_NAME,
         deployVersion: 'ADDON_DOCS_DEPLOY_VERSION'
       }
     };
@@ -107,10 +114,7 @@ module.exports = {
 
   createDeployPlugin() {
     const AddonDocsDeployPlugin = require('./lib/deploy/plugin');
-    const readConfig = require('./lib/utils/read-config');
-
-    let userConfig = readConfig(this.project);
-    return new AddonDocsDeployPlugin(userConfig);
+    return new AddonDocsDeployPlugin(this._readUserConfig());
   },
 
   setupPreprocessorRegistry(type, registry) {
@@ -210,6 +214,15 @@ module.exports = {
       srcDir: 'styles',
       destDir: 'highlightjs-styles'
     });
+  },
+
+  _readUserConfig() {
+    if (!this._userConfig) {
+      const readConfig = require('./lib/utils/read-config');
+      this._userConfig = readConfig(this.project);
+    }
+
+    return this._userConfig;
   }
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,10 @@ module.exports = class AddonDocsConfig {
     this.repoInfo = gitRepoInfo();
   }
 
+  getPrimaryBranch() {
+    return 'master';
+  }
+
   getRootURL() {
     let repository = this.project.pkg.repository || '';
     let info = hostedGitInfo.fromUrl(repository.url || repository);

--- a/lib/deploy/plugin.js
+++ b/lib/deploy/plugin.js
@@ -8,6 +8,7 @@ const hostedGitInfo = require('hosted-git-info');
 const walkSync = require('walk-sync');
 
 const VERSION_PREFIX = 'v';
+const { LATEST_VERSION_NAME } = require('../..');
 
 module.exports = class AddonDocsDeployPlugin {
   constructor(userConfig) {
@@ -83,7 +84,7 @@ module.exports = class AddonDocsDeployPlugin {
     versions[version.name] = version;
 
     if (this.userConfig.shouldUpdateLatest()) {
-      versions['latest'] = this._latestDeployVersion();
+      versions[LATEST_VERSION_NAME] = this._latestDeployVersion();
     }
 
     fs.writeJSONSync(versionsFile, versions, { spaces: 2 });
@@ -150,7 +151,7 @@ module.exports = class AddonDocsDeployPlugin {
 
   _latestDeployVersion() {
     let path = '';
-    let name = 'latest';
+    let name = LATEST_VERSION_NAME;
     let sha = this.userConfig.repoInfo.sha;
     let tag = this.userConfig.repoInfo.tag;
     return { path, name, sha, tag };

--- a/tests/acceptance/version-selector-test.js
+++ b/tests/acceptance/version-selector-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { visit, click } from '@ember/test-helpers';
+import config from 'dummy/config/environment';
 
 module('Acceptance | Version selector test', function(hooks) {
   setupApplicationTest(hooks);
@@ -11,8 +12,8 @@ module('Acceptance | Version selector test', function(hooks) {
     this.owner.lookup('service:project-version').set('currentVersion', {
       "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
       "tag": 'v0.1.0',
-      "path": "latest",
-      "name": "latest"
+      "path": "",
+      "name": "-latest"
     });
 
     await visit('/');
@@ -24,8 +25,8 @@ module('Acceptance | Version selector test', function(hooks) {
     this.owner.lookup('service:project-version').set('currentVersion', {
       "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
       "tag": null,
-      "path": "latest",
-      "name": "latest"
+      "path": "",
+      "name": "-latest"
     });
 
     await visit('/');
@@ -35,11 +36,11 @@ module('Acceptance | Version selector test', function(hooks) {
 
   test(`the version selector renders correctly`, async function(assert) {
     server.get('/versions.json', {
-      "latest": {
+      "-latest": {
         "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
         "tag": null,
-        "path": "latest",
-        "name": "latest"
+        "path": "",
+        "name": "-latest"
       },
       "master": {
         "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
@@ -71,11 +72,11 @@ module('Acceptance | Version selector test', function(hooks) {
 
   test(`the version selector renders a tag for latest if present`, async function(assert) {
     server.get('/versions.json', {
-      "latest": {
+      "-latest": {
         "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
         "tag": 'v0.1.0',
-        "path": "latest",
-        "name": "latest"
+        "path": "",
+        "name": "-latest"
       },
       "master": {
         "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
@@ -97,4 +98,52 @@ module('Acceptance | Version selector test', function(hooks) {
     assert.dom('[data-test-id="version"]:nth-child(1)').includesText('Latest', 'latest is rendered first');
     assert.dom('[data-test-id="version"]:nth-child(1)').includesText('v0.1.0', 'latest renders a tag if present');
   });
+
+  module('with a custom primary branch configured', function(hooks) {
+    let oldPrimaryBranch;
+    hooks.beforeEach(function() {
+      oldPrimaryBranch = config.primaryBranch;
+      config.primaryBranch = 'develop';
+    });
+
+    hooks.afterEach(function() {
+      config.primaryBranch = oldPrimaryBranch;
+    });
+
+    test(`the version selector honors the primary branch`, async function(assert) {
+      server.get('/versions.json', {
+        "-latest": {
+          "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
+          "tag": null,
+          "path": "",
+          "name": "-latest"
+        },
+        "master": {
+          "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
+          "tag": null,
+          "path": "master",
+          "name": "master"
+        },
+        "develop": {
+          "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
+          "tag": null,
+          "path": "develop",
+          "name": "develop"
+        }
+      });
+
+      await visit('/');
+      await click('[data-test-id="current-version"]');
+
+      assert.dom('[data-test-id="version"]:nth-child(1)').includesText('Latest', 'latest is rendered first');
+      assert.dom('[data-test-id="version"]:nth-child(1)').includesText('53b73', 'latest renders a sha when tag is null');
+      assert.dom('[data-test-id="version"]:nth-child(1)').includesText('check', 'the current version has a check');
+
+      assert.dom('[data-test-id="version"]:nth-child(2)').includesText('develop', 'develop is rendered second');
+      assert.dom('[data-test-id="version"]:nth-child(2)').includesText('53b73');
+
+      assert.dom('[data-test-id="version"]:nth-child(3)').includesText('master', 'other branches are rendered last');
+      assert.dom('[data-test-id="version"]:nth-child(3)').includesText('53b73');
+    });
+  })
 });

--- a/tests/dummy/app/pods/docs/deploying/template.md
+++ b/tests/dummy/app/pods/docs/deploying/template.md
@@ -142,6 +142,10 @@ If instead, however, you want to [set up a CNAME for your project](https://help.
 
 **Note**: if you change this configuration after you've already deployed copies of your docs site, you'll need to check out your `gh-pages` branch and find/replace your previous root URL in those copies in order for them to continue to function in their new location.
 
+### `getPrimaryBranch()`
+
+This method determines what Addon Docs considers to be your primary branch, which is where links such as "edit this page" will point. By default, this branch is `master`, but you can override this method to choose a different branch instead, e.g. `develop`.
+
 ## Removing a deployed version
 
 Deploying a version of your documentation does two things: it copies the `dist` directory of your built docs app into a particular place on your `gh-pages` branch, and it adds or updates an entry in the `versions.json` manifest in the root of that branch. To remove a version, then, you just need to undo those two things.

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -4,11 +4,11 @@ const projectTag = config['ember-cli-addon-docs'].projectTag;
 export default function() {
   this.get('/versions.json', () => {
     return {
-      "latest": {
+      "-latest": {
         "sha": "53b73465d31925f26fd1f77881aefcaccce2915a",
         "tag": projectTag,
-        "path": "latest",
-        "name": "latest"
+        "path": "",
+        "name": "-latest"
       },
       "master": {
         "sha": "12345",


### PR DESCRIPTION
Building on the work to move the deploy of the latest release into the root directory, this PR eliminates places where we have hard-coded specialized behavior for versions called `latest` or `master`. For the former, I've changed the key to `-latest` and moved it into a shared constant. For the latter, `master` is now the default value for a `getPrimaryBranch()` hook that devs can override.

Using `-latest` rather than `latest` should help to some degree in mitigating the likelihood of name clashes with actual branches, and since we're due for a breaking release, this seems like the time to make that change. Allowing for configuration of the primary branch should fix #181 and help folks using strategies like [git-flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) where the primary branch is `develop` rather than `master`.

@ef4 @savvymas where do things stand with the auto-migration code? Ideally we'd incorporate the `latest` -> `-latest` change in `versions.json` there—I'm happy to add that whenever the script is ready to share.