### PR TITLE
[bugfix] Prevents all Marked escaping in plain text

### DIFF
--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -74,13 +74,17 @@ class HBSRenderer extends marked.Renderer {
     return code.replace(/^<pre>/, '<pre class="docs-md__code">');
   }
 
-  // Unescape quotes in text, as they may be part of a Handlebars statement
+  // Unescape markdown escaping in general, since it can interfere with
+  // Handlebars templating
   text() {
     let text = super.text.apply(this, arguments);
     if (this.config.targetHandlebars) {
       text = text
-        .replace(/&quot;|&#34;/g, `"`)
-        .replace(/&apos;|&#39;/g, `'`);
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;|&#34;/g, '"')
+        .replace(/&apos;|&#39;/g, '\'');
     }
     return text;
   }

--- a/tests-node/unit/utils/compile-markdown-test.js
+++ b/tests-node/unit/utils/compile-markdown-test.js
@@ -37,4 +37,32 @@ QUnit.module('Unit | compile-markdown', function(hooks) {
 
     assert.equal(result, expected);
   });
+
+  test('classic components remain unescaped', function(assert) {
+    let input = stripIndent`
+      {{#foo-bar prop="value" otherProp='value'}}
+
+      {{/foo-bar}}
+    `;
+
+    let result = compileMarkdown(input, { targetHandlebars: true });
+    let expected = stripIndent`
+      <div class="docs-md"><p>{{#foo-bar prop="value" otherProp='value'}} {{/foo-bar}}</p></div>
+    `;
+
+    assert.equal(result, expected);
+  });
+
+  test('angle bracket contextual components remain unescaped', function(assert) {
+    let input = stripIndent`
+      <foo.bar @prop={{value}}></foo.bar>
+    `;
+
+    let result = compileMarkdown(input, { targetHandlebars: true });
+    let expected = stripIndent`
+      <div class="docs-md"><p><foo.bar @prop={{value}}></foo.bar></p></div>
+    `;
+
+    assert.equal(result, expected);
+  });
 });


### PR DESCRIPTION
This ensures that _all_ escaped characters are unescaped when rendering
markdown. Should minimize the impact Marked has on our templates. I've
also opened an issue with Marked directly to see if we can upstream
this.