### PR TITLE
Allow child routes under docs pages

### DIFF
--- a/addon/components/docs-viewer/x-main/template.hbs
+++ b/addon/components/docs-viewer/x-main/template.hbs
@@ -26,7 +26,7 @@
       {{/if}}
     </div>
 
-    <div class="w-1/2 text-right">
+    <div class="w-1/2 text-right" data-test-next-link>
       {{#if docsRoutes.next}}
         <div class='text-sm text-grey-dark'>
           Next

--- a/addon/services/docs-routes.js
+++ b/addon/services/docs-routes.js
@@ -39,14 +39,16 @@ export default Service.extend({
     if (this.get('routeUrls.length')) {
       let router = this.get('router.router');
       let currentURL = router.get('rootURL') + router.get('url');
-      currentURL = currentURL
-        .replace('//', '/')   // dedup slashes
-        .replace(/\?.+$/, '') // remove query-params
-        .replace(/\/$/, '')   // remove trailing slash
-        .replace(/#.+$/, ''); // remove # anchor links
-      let index = this.get('routeUrls').indexOf(currentURL);
-      assert(`DocsRoutes wasn't able to correctly detect the current route. The current url is ${currentURL}`, index > -1);
-      return index;
+      currentURL = currentURL.replace('//', '/')   // dedup slashes
+      let longestIndex, longestPrefix;
+      this.get('routeUrls').forEach((url, index) => {
+        if (currentURL.indexOf(url) === 0 && (!longestPrefix || url.length > longestPrefix.length)) {
+          longestIndex = index;
+          longestPrefix = url;
+        }
+      });
+      assert(`DocsRoutes wasn't able to correctly detect the current route. The current url is ${currentURL}`, longestIndex != null);
+      return longestIndex;
     }
   }),
 

--- a/tests/acceptance/docs-route-test.js
+++ b/tests/acceptance/docs-route-test.js
@@ -21,7 +21,7 @@ module('Acceptance | Docs route test', function(hooks) {
   });
 
   test('I can visit a nested child route within the docs pages and still have the correct links', async function(assert) {
-    await visit('/docs/deploying/test-nested-route');
-    assert.dom('[data-test-next-link] > a').hasText('Hero');
+    await visit('/sandbox/docs/one/child');
+    assert.dom('[data-test-next-link] > a').hasText('Two');
   });
 });

--- a/tests/acceptance/docs-route-test.js
+++ b/tests/acceptance/docs-route-test.js
@@ -19,4 +19,9 @@ module('Acceptance | Docs route test', function(hooks) {
 
     assert.dom('h1').hasText('DocsHero');
   });
+
+  test('I can visit a nested child route within the docs pages and still have the correct links', async function(assert) {
+    await visit('/docs/deploying/test-nested-route');
+    assert.dom('[data-test-next-link] > a').hasText('Hero');
+  });
 });

--- a/tests/dummy/app/pods/sandbox/template.hbs
+++ b/tests/dummy/app/pods/sandbox/template.hbs
@@ -2,6 +2,8 @@
   {{#viewer.nav project=model root='sandbox' as |nav|}}
     {{nav.section 'The Sandbox'}}
     {{nav.item 'Welcome' 'sandbox.index'}}
+    {{nav.item 'One' 'sandbox.docs.one'}}
+    {{nav.item 'Two' 'sandbox.docs.two'}}
   {{/viewer.nav}}
 
   {{#viewer.main}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,7 +12,11 @@ Router.map(function() {
     this.route('usage');
     this.route('quickstart');
     this.route('patterns');
-    this.route('deploying');
+    this.route('deploying', function() {
+      // This exists so we can acceptance test whether the docs pages tolerate
+      // embedded child routes. It's not used in the public documentation site.
+      this.route('test-nested-route');
+    });
 
     this.route('components', function() {
       this.route('docs-hero');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,11 +12,7 @@ Router.map(function() {
     this.route('usage');
     this.route('quickstart');
     this.route('patterns');
-    this.route('deploying', function() {
-      // This exists so we can acceptance test whether the docs pages tolerate
-      // embedded child routes. It's not used in the public documentation site.
-      this.route('test-nested-route');
-    });
+    this.route('deploying');
 
     this.route('components', function() {
       this.route('docs-hero');
@@ -30,6 +26,12 @@ Router.map(function() {
 
   this.route('sandbox', function() {
     apiRoute(this);
+    docsRoute(this, function() {
+      this.route('one', function() {
+        this.route('child');
+      });
+      this.route('two');
+    });
   });
 
   this.route('not-found', { path: '/*path' });


### PR DESCRIPTION
(authored while pairing with @ef4)

This makes the docs-route service more tolerant of pages with their own internal URL structure. For example, we're using this in ember-animated to have a page that includes an outlet in order to demonstrate cross-route animations.