### PR TITLE
Upgrade ember-svg-jar

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-modal-dialog": "2.4.3",
     "ember-responsive": "^3.0.0-beta.1",
     "ember-router-scroll": "^0.6.0",
-    "ember-svg-jar": "^0.12.0",
+    "ember-svg-jar": "^1.2.1",
     "ember-tether": "^1.0.0-beta.2",
     "ember-truth-helpers": "^2.0.0",
     "execa": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,7 +1372,7 @@ broccoli-builder@^0.18.8:
     rsvp "^3.0.17"
     silent-error "^1.0.1"
 
-broccoli-caching-writer@^2.2.0, broccoli-caching-writer@^2.3.1:
+broccoli-caching-writer@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz#b93cf58f9264f003075868db05774f4e7f25bd07"
   dependencies:
@@ -1402,19 +1402,6 @@ broccoli-clean-css@^1.1.0:
     clean-css-promise "^0.1.0"
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
-
-broccoli-concat@^2.2.0:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-2.3.8.tgz#590cdcc021bb905b6c121d87c2d1d57df44a2a48"
-  dependencies:
-    broccoli-caching-writer "^2.3.1"
-    broccoli-kitchen-sink-helpers "^0.3.1"
-    broccoli-stew "^1.3.3"
-    fast-sourcemap-concat "^1.0.1"
-    fs-extra "^0.30.0"
-    lodash.merge "^4.3.0"
-    lodash.omit "^4.1.0"
-    lodash.uniq "^4.2.0"
 
 broccoli-concat@^3.2.2:
   version "3.2.2"
@@ -1751,24 +1738,25 @@ broccoli-style-manifest@^1.4.0:
     rsvp "^4.7.0"
     walk-sync "^0.3.1"
 
-broccoli-svg-optimizer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/broccoli-svg-optimizer/-/broccoli-svg-optimizer-1.0.2.tgz#b12e84e65912f3134939cbf766c3fa0b4d0d92d9"
+broccoli-svg-optimizer@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-svg-optimizer/-/broccoli-svg-optimizer-1.1.0.tgz#5d6e03310298c7a1d22d373508beedc6258590cc"
   dependencies:
     broccoli-persistent-filter "^1.2.0"
     json-stable-stringify "^1.0.1"
-    rsvp "^3.2.1"
-    svgo "^0.6.6"
+    lodash "^4.17.10"
+    rsvp "^4.8.2"
+    svgo "0.6.6"
 
-broccoli-symbolizer@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/broccoli-symbolizer/-/broccoli-symbolizer-0.5.0.tgz#c666d4158ff4484263daaee9a6284d684b6eb3a2"
+broccoli-symbolizer@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/broccoli-symbolizer/-/broccoli-symbolizer-0.6.0.tgz#1ece00fba329f19ab42d920350a5f2014f8d0b52"
   dependencies:
-    broccoli-concat "^2.2.0"
+    broccoli-concat "^3.2.2"
     broccoli-persistent-filter "^1.2.0"
-    cheerio "^0.20.0"
+    cheerio "^0.22.0"
     json-stable-stringify "^1.0.1"
-    lodash "^4.13.1"
+    lodash "^4.17.10"
 
 broccoli-templater@^1.0.0:
   version "1.0.0"
@@ -2004,7 +1992,7 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
-cheerio@0.20.0, cheerio@^0.20.0:
+cheerio@0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.20.0.tgz#5c710f2bab95653272842ba01c6ea61b3545ec35"
   dependencies:
@@ -2016,7 +2004,7 @@ cheerio@0.20.0, cheerio@^0.20.0:
   optionalDependencies:
     jsdom "^7.0.2"
 
-cheerio@0.22.0:
+cheerio@0.22.0, cheerio@^0.22.0:
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
   dependencies:
@@ -3329,6 +3317,12 @@ ember-concurrency@^0.8.16:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
+ember-copy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-data@^2.18.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.18.1.tgz#306d8fb272f113ab35db022f9a47a298720ba2dc"
@@ -3585,18 +3579,19 @@ ember-source@~3.0.0:
     jquery "^3.2.1"
     resolve "^1.3.3"
 
-ember-svg-jar@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/ember-svg-jar/-/ember-svg-jar-0.12.0.tgz#558253e7b6f2617e1d04aa13fb2bb6c6c1924020"
+ember-svg-jar@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-svg-jar/-/ember-svg-jar-1.2.1.tgz#a6f2c2404eec72aaa819b66407cec0ebe72be99b"
   dependencies:
-    broccoli-caching-writer "^2.3.1"
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
+    broccoli-caching-writer "^3.0.3"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
     broccoli-string-replace "^0.1.2"
-    broccoli-svg-optimizer "^1.0.2"
-    broccoli-symbolizer "^0.5.0"
-    cheerio "^0.20.0"
+    broccoli-svg-optimizer "1.1.0"
+    broccoli-symbolizer "^0.6.0"
+    cheerio "^0.22.0"
     ember-cli-babel "^6.6.0"
+    ember-copy "^1.0.0"
     lodash "^4.13.1"
     mkdirp "^0.5.1"
     path-posix "^1.0.0"
@@ -8609,7 +8604,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-svgo@^0.6.6:
+svgo@0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.6.6.tgz#b340889036f20f9b447543077d0f5573ed044c08"
   dependencies:


### PR DESCRIPTION
This version has many bugfixes, and we're already using it in ember-animated docs, so this eliminates a conflict for us.

There were no breaking changes.

(authored while pairing with @ef4)