### PR TITLE
Update 'Edit this page' link regex

### DIFF
--- a/addon/components/docs-viewer/x-main/component.js
+++ b/addon/components/docs-viewer/x-main/component.js
@@ -80,7 +80,7 @@ export default Component.extend({
       }
     } else {
       let file = appFiles
-        .filter(file => file.match(/template.+(hbs|md)/))
+        .filter(file => file.match(/\.(hbs|md)$/))
         .find(file => file.match(path));
 
       return `${projectHref}/edit/${primaryBranch}/tests/dummy/app/${file}`;


### PR DESCRIPTION
This PR updates the `Edit this link` filter regex from
* `template.+(hbs|md)`
to
* `\.(hbs|md)$`

this removes the necessity to have the string "template" in doc filenames, in turn preventing dead links such as https://github.com/user/repo/edit/branch/undefined

I'm not too concerned about the trialing `$` if it's not agreeable but happy to discuss.
