### PR TITLE
Omit <a> title attribute if title is null

### DIFF
--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -122,6 +122,7 @@ class HBSRenderer extends marked.Renderer {
   }
 
   link(href, title, text) {
-    return `<a href="${href}" title="${title}" class="docs-md__a">${text}</a>`;
+    const titleAttribute = title ? `title="${title}"` : '';
+    return `<a href="${href}" ${titleAttribute} class="docs-md__a">${text}</a>`;
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "liquid-fire": "^0.29.1",
     "lodash": "^4.17.5",
     "lunr": "^2.1.5",
-    "marked": "^0.3.12",
+    "marked": "^0.5.0",
     "parse-git-config": "^1.1.1",
     "quick-temp": "^0.1.8",
     "resolve": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6332,9 +6332,9 @@ marked@0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-marked@^0.3.12:
-  version "0.3.16"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.16.tgz#2f188b7dfcfa6540fe9940adaf0f3b791c9a5cba"
+marked@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.0.tgz#9e590bad31584a48ff405b33ab1c0dd25172288e"
 
 match-media@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR tweaks the `title()` method of the `HBSRenderer` in [lib/utils/compile-markdown.js](https://github.com/22a/ember-cli-addon-docs/blob/b75247734aff43f30a63f51e090f8d60a857ba02/lib/utils/compile-markdown.js#L124-L127) to only add a title attribute to the html snippet when the passed `title` argument is truthy. 

This prevents adding `null` (and perhaps also `undefined`, but I haven't encountered that yet) title attributes to `a` tags, such as this ([visible here](https://ember-learn.github.io/ember-cli-addon-docs/docs)):

<img width="512" alt="image of the string 'null' title attribute visible when hovering over a link" src="https://user-images.githubusercontent.com/7144173/45317443-ed0edf80-b531-11e8-97e5-50dc233eb1bc.png">

---

This PR also bumps the [`marked`](https://github.com/markedjs/marked) dependency from `^0.3.12` to `^0.5.0` for no particular reason other than to keep it up to date - I don't feel strongly about this and I'm happy to remove this change from the PR if you'd prefer.