### PR TITLE
Ember data 2 or 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-code-snippet": "^2.2.0",
     "ember-component-css": "^0.3.5",
     "ember-concurrency": "^0.8.16",
-    "ember-data": "^3.4.0",
+    "ember-data": "2.x - 3.x",
     "ember-fetch": "^4.0.2",
     "ember-fetch-adapter": "^0.4.2",
     "ember-href-to": "^1.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,7 +3358,7 @@ ember-copy@^1.0.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-data@^3.4.0:
+"ember-data@2.x - 3.x":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.4.0.tgz#d303057d560b0002f5b1490a7c24c4bfb74cd2fa"
   dependencies:


### PR DESCRIPTION
This is a PR for Issue https://github.com/ember-learn/ember-cli-addon-docs/issues/242

It allows addon docs to accept a wider range of Ember Data versions. This way it won't conflict with the host addon's data dependency. 

