### PR TITLE
Updated disable deploy docs

### DIFF
--- a/tests/dummy/app/pods/docs/deploying/template.md
+++ b/tests/dummy/app/pods/docs/deploying/template.md
@@ -177,7 +177,7 @@ If you wish to disable ember-cli-addon-docs' built-in deployment plugins altoget
 // ...
 ENV.pipeline = {
   disabled: {
-    'addon-docs': true
+    'ember-cli-addon-docs': true
   }
 };
 // ...


### PR DESCRIPTION
When I tried to use this config to disable the addon-docs deployment plugins I got the following warning in my terminal.

```
Your config has referenced the following unknown plugins or aliases in `config.pipeline.disabled`:

- addon-docs
```

It appears that simply using `addon-docs` is not a valid alias for disabling the `ember-cli-addon-docs` deployment plugins.

In the below screenshot if I put a breakpoint inside the [ember-cli-deploy code](https://github.com/ember-cli-deploy/ember-cli-deploy/blob/b6df8fb3d7d7e798092cab5721b921abe0435dee/lib/models/plugin-registry.js#L101) you can see the alias that appears.

![image](https://user-images.githubusercontent.com/685034/46170668-4dbe4c00-c296-11e8-9bc3-3dba857adf0d.png)

I'm imagining `ember-cli-deploy-git` and `ember-cli-deploy-git-ci` appear as `git` and `git-ci` as the `ember-cli-deploy-` gets snipped.