### PR TITLE
Inform to github that scripts/parallel is vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/parallel linguist-vendored


### PR DESCRIPTION
This apparently worked for ember-auto-import: https://github.com/ef4/ember-auto-import/blob/master/.gitattributes
