### PR TITLE
Fix issues with empty rootURL

### DIFF
--- a/lib/deploy/plugin.js
+++ b/lib/deploy/plugin.js
@@ -64,7 +64,7 @@ module.exports = class AddonDocsDeployPlugin {
 
   _verifyRedirectFile(stagingDirectory) {
     let vendorDir = `${__dirname}/../../vendor/ember-cli-addon-docs`;
-    let segmentCount = this._getRootURL().split('/').length;
+    let segmentCount = this._getRootURL().split('/').filter(Boolean).length;
     let redirectContents = fs.readFileSync(`${vendorDir}/404.html`, 'utf-8');
     let redirects = this._discoverOldPaths(stagingDirectory);
 

--- a/lib/deploy/plugin.js
+++ b/lib/deploy/plugin.js
@@ -150,10 +150,10 @@ module.exports = class AddonDocsDeployPlugin {
 
   _updateIndexContents(context, stagingDirectory, appRoot, deployVersion) {
     let indexPath = `${stagingDirectory}/${appRoot}/index.html`;
-    let rootURL = [this._getRootURL(), appRoot].filter(Boolean).join('/');
+    let rootURL = [this._getRootURL(), appRoot].filter(Boolean).join('/').replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, '/$1/') || '/';
     let contents = fs.readFileSync(indexPath, 'utf-8');
     let encodedVersion = encodeURIComponent(JSON.stringify(deployVersion));
-    let updated = contents.replace(/\/?ADDON_DOCS_ROOT_URL\/?/g, `/${rootURL}/`)
+    let updated = contents.replace(/\/?ADDON_DOCS_ROOT_URL\/?/g, `${rootURL}`)
       .replace(/%22ADDON_DOCS_DEPLOY_VERSION%22/g, encodedVersion);
 
     fs.writeFileSync(indexPath, updated);


### PR DESCRIPTION
This will close #265 

Incorrect segmentCount was calculated and doubles slashes were inserted when using an empty string as rootURL (as the doc suggest to do with a custom domain configuration)