### PR TITLE
Fix a typo in the code example of `docs-hero`

### DIFF
--- a/addon/components/docs-hero/component.js
+++ b/addon/components/docs-hero/component.js
@@ -11,7 +11,7 @@ const { projectName, projectDescription } = config['ember-cli-addon-docs'];
   ```hbs
   {{docs-hero
     prefix='Ember'
-    headding='SuperAddon'
+    heading='SuperAddon'
     byline='The best addon ever. Now playing in theaters.'}}
   ```
 


### PR DESCRIPTION
Fix a typo in the code example of `docs-hero`