### PR TITLE
Fix usage of a test selector on a tagless component

### DIFF
--- a/addon/components/docs-header/template.hbs
+++ b/addon/components/docs-header/template.hbs
@@ -23,8 +23,8 @@
 
       {{docs-header/search-box query=query on-input=(action (mut query))}}
 
-      {{#docs-header/link on-click=(action (toggle 'isShowingVersionSelector' this)) data-test-id='current-version'}}
-        <span data-version-selector class='docs-flex docs-items-center'>
+      {{#docs-header/link on-click=(action (toggle 'isShowingVersionSelector' this))}}
+        <span data-test-id="current-version" data-version-selector class='docs-flex docs-items-center'>
 
           {{#if (or (eq currentVersion.key latestVersionName))}}
             {{#if currentVersion.tag}}


### PR DESCRIPTION
`{{docs-header/link}}` is a tagless component which means we can't apply a test selector on it. `ember-test-selectors` used to throw a warning however they changed it to an assertion which results in breaking all addons using this addon and `ember-test-selectors`. I actually don't know how those tests for this functionality ever worked :thinking: