### PR TITLE
Fix markdown parser

### DIFF
--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -47,7 +47,9 @@ function compactParagraphs(tokens) {
     }
 
     balance += count(/\{\{#/g, token.text);
+    balance += count(/<[A-Z]/g, token.text);
     balance -= count(/\{\{\//g, token.text);
+    balance -= count(/<\/[A-Z]/g, token.text);
   }
 
   return compacted;

--- a/tests-node/unit/utils/compile-markdown-test.js
+++ b/tests-node/unit/utils/compile-markdown-test.js
@@ -5,7 +5,7 @@ const stripIndent = require('common-tags').stripIndent;
 const compileMarkdown = require('../../../lib/utils/compile-markdown');
 
 QUnit.module('Unit | compile-markdown', function(hooks) {
-  test('compacting paragraphs', function(assert) {
+  test('compacting curly paragraphs', function(assert) {
     let input = stripIndent`
       {{#foo-bar}}
 
@@ -15,6 +15,24 @@ QUnit.module('Unit | compile-markdown', function(hooks) {
     let result = compileMarkdown(input, { targetHandlebars: true });
     let expected = stripIndent`
       <div class="docs-md"><p>{{#foo-bar}} {{/foo-bar}}</p></div>
+    `;
+
+    assert.equal(result, expected);
+  });
+
+  test('compacting angle bracket paragraphs', function(assert) {
+    let input = stripIndent`
+      <FooBar>
+
+      </FooBar>
+    `;
+
+    // TODO: there is a space left before the closing tag but build is not broken :)
+    let result = compileMarkdown(input, { targetHandlebars: true });
+    let expected = stripIndent`
+      <div class="docs-md"><FooBar>
+
+       </FooBar></div>
     `;
 
     assert.equal(result, expected);


### PR DESCRIPTION
With version `0.6.0` and using angle bracket syntax inside your markdown files will actually brake the build.

This is **not** working:

```
<DocsDemo @class="docs-demo" as |demo|>
  {{#demo.example name='demo.hbs'}}
    <FooBar @label="fubar"/>
  {{/demo.example}}

  {{demo.snippet 'demo.hbs'}}
</DocsDemo>
```

This patch fixes the parser to not only handle curlies but also angle brackets :)