### PR TITLE
Pin tough-cookie to support Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
     "qunit": "^2.6.2",
     "qunit-dom": "^0.8.0"
   },
+  "resolutions": {
+    "**/tough-cookie": "~2.4.0"
+  },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },


### PR DESCRIPTION
Should be ablve to remove this if/when https://github.com/salesforce/tough-cookie/pull/141 is merged.

Fixes https://github.com/ember-learn/ember-cli-addon-docs/issues/298