### PR TITLE
Add docs route in quickstart section

### DIFF
--- a/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/quickstart/template.md
@@ -59,6 +59,12 @@ all docs pages in your site.
     {{/docs-viewer}}
   {{/docs-snippet}}
 
+  {{#docs-snippet name='quickstart-skeleton.js' title='tests/dummy/app/routes/docs.js'}}
+    import BaseDocsRoute from 'ember-cli-addon-docs/routes/docs'
+
+    export default class DocsRoute extends BaseDocsRoute {}
+  {{/docs-snippet}}
+
 5. **Create your Markdown templates.** Markdown templates contain the actual
 documentation for your addon and live in the folder
 `tests/dummy/app/templates/docs`. Since Addon Docs supports Markdown out


### PR DESCRIPTION
This has proved to fix a weird bug I had in an addon.


**Reproduction Steps**
- visit https://qonto.github.io/ember-phone-input/
- click `Read the docs`
- click `API REFERENCE -> Components -> phone-input`
- refresh the page

**Bug**
API section is not rendered anymore.

**Investigation**
For some reason, the `ember-cli-addon-docs/routes/docs`'s `model` hook is not played.

**Resolution / work-around**
I've created a route `tests/dummy/app/pods/docs/route.js` and extended it from e-c-a-d's. The model is now always triggered.