### PR TITLE
support opening tags inside backticks

### DIFF
--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -46,10 +46,13 @@ function compactParagraphs(tokens) {
       last.text = `${last.text} ${token.text}`;
     }
 
-    balance += count(/(?<!`.*){{#/g, token.text);
-    balance += count(/(?<!`.*)<[A-Z]/g, token.text);
-    balance -= count(/{{\/.*}}(?!.*`)/g, token.text);
-    balance -= count(/<\/[A-Z][a-z]+>(?!.*`)/g, token.text);
+    let tokenText = token.text || '';
+    let textWithoutCode = tokenText.replace(/`[\s\S]*?`/g, '');
+
+    balance += count(/{{#/g, textWithoutCode);
+    balance += count(/<[A-Z]/g, textWithoutCode);
+    balance -= count(/{{\//g, textWithoutCode);
+    balance -= count(/<\/[A-Z]/g, textWithoutCode);
   }
 
   return compacted;

--- a/lib/utils/compile-markdown.js
+++ b/lib/utils/compile-markdown.js
@@ -46,10 +46,10 @@ function compactParagraphs(tokens) {
       last.text = `${last.text} ${token.text}`;
     }
 
-    balance += count(/\{\{#/g, token.text);
-    balance += count(/<[A-Z]/g, token.text);
-    balance -= count(/\{\{\//g, token.text);
-    balance -= count(/<\/[A-Z]/g, token.text);
+    balance += count(/(?<!`.*){{#/g, token.text);
+    balance += count(/(?<!`.*)<[A-Z]/g, token.text);
+    balance -= count(/{{\/.*}}(?!.*`)/g, token.text);
+    balance -= count(/<\/[A-Z][a-z]+>(?!.*`)/g, token.text);
   }
 
   return compacted;

--- a/tests-node/unit/utils/compile-markdown-test.js
+++ b/tests-node/unit/utils/compile-markdown-test.js
@@ -83,4 +83,36 @@ QUnit.module('Unit | compile-markdown', function(hooks) {
 
     assert.equal(result, expected);
   });
+
+  test('using opening curlies inside backticks shouldn\'t compact paragraphs', function(assert) {
+    let input = stripIndent`
+      Foo bar is \`{{#my-component}}\`.
+
+      Another paragraph.
+    `;
+
+    let result = compileMarkdown(input, { targetHandlebars: true });
+    let expected = stripIndent`
+      <div class="docs-md"><p>Foo bar is <code>&#123;&#123;#my-component&#125;&#125;</code>.</p>
+      <p>Another paragraph.</p></div>
+    `;
+
+    assert.equal(result, expected);
+  });
+
+  test('using opening angle brackets inside backticks shouldn\'t compact paragraphs', function(assert) {
+    let input = stripIndent`
+      Foo bar is \`<My component>\`.
+
+      Another paragraph.
+    `;
+
+    let result = compileMarkdown(input, { targetHandlebars: true });
+    let expected = stripIndent`
+      <div class="docs-md"><p>Foo bar is <code>&lt;My component&gt;</code>.</p>
+      <p>Another paragraph.</p></div>
+    `;
+
+    assert.equal(result, expected);
+  });
 });


### PR DESCRIPTION
Fixes #306 

Basically I updated the regexes with negative lookbehinds and lookaheads. From my quick research, negative lookbehinds were introduced in node 6, so we should be good. lookaheads were always supported, afaik.