### PR TITLE
wrap nav and snippet in a div 

### DIFF
--- a/addon/components/docs-demo/template.hbs
+++ b/addon/components/docs-demo/template.hbs
@@ -5,28 +5,30 @@
     snippet=(component 'docs-demo/x-snippet' did-init=(action 'registerSnippet') activeSnippet=activeSnippet)
   )}}
 
-  {{#if snippets}}
-    <nav class="docs-demo__snippets-nav docs-py-2 docs-px-4 docs-font-medium docs-bg-grey-lighter docs-tracking-tight">
-      {{#each snippets as |snippet|}}
-        <button {{action 'selectSnippet' snippet}}
-          class='
-            docs-mr-4 docs-text-xs docs-no-underline outline-none
-            hover:docs-text-grey-darkest
-            {{if snippet.isActive 'docs-text-grey-darkest' 'docs-text-grey-dark'}}
-          '
-        >
-          {{snippet.label}}
-        </button>
-      {{/each}}
-    </nav>
-  {{/if}}
-
-  {{#each snippets as |snippet|}}
-    {{#if snippet.isActive}}
-      <div class="docs-demo__snippet-wrapper">
-        {{docs-snippet name=snippet.name unindent=true language=snippet.language}}
-      </div>
+  <div>
+    {{#if snippets}}
+      <nav class="docs-demo__snippets-nav docs-py-2 docs-px-4 docs-font-medium docs-bg-grey-lighter docs-tracking-tight">
+        {{#each snippets as |snippet|}}
+          <button {{action 'selectSnippet' snippet}}
+            class='
+              docs-mr-4 docs-text-xs docs-no-underline outline-none
+              hover:docs-text-grey-darkest
+              {{if snippet.isActive 'docs-text-grey-darkest' 'docs-text-grey-dark'}}
+            '
+          >
+            {{snippet.label}}
+          </button>
+        {{/each}}
+      </nav>
     {{/if}}
-  {{/each}}
+
+    {{#each snippets as |snippet|}}
+      {{#if snippet.isActive}}
+        <div class="docs-demo__snippet-wrapper">
+          {{docs-snippet name=snippet.name unindent=true language=snippet.language}}
+        </div>
+      {{/if}}
+    {{/each}}
+  </div>
 
 </div>


### PR DESCRIPTION
This just wraps the nav and snippet in a div.
This way it's very easy to have horizontal demos by just adding the `docs-flex docs-flex-row` classes to the docs-demo component. Results in something like this:

![screen shot 2019-01-31 at 17 39 20](https://user-images.githubusercontent.com/631691/52073354-2f879600-257f-11e9-810c-9083ed743a87.png)

Doesn't affect any existing vertical demos.

If an `horizontal=true` flag is desired, I can add it. It could add those classes to the container and also apply a left border on the snippet.