### PR TITLE
hide snippet nav when demo has a single snippet

### DIFF
--- a/addon/components/docs-demo/template.hbs
+++ b/addon/components/docs-demo/template.hbs
@@ -6,7 +6,7 @@
   )}}
 
   <div>
-    {{#if snippets}}
+    {{#if (and snippets (gt snippets.length 1))}}
       <nav class="docs-demo__snippets-nav docs-py-2 docs-px-4 docs-font-medium docs-bg-grey-lighter docs-tracking-tight">
         {{#each snippets as |snippet|}}
           <button {{action 'selectSnippet' snippet}}


### PR DESCRIPTION
Only shows snippet nav when more than one snippet is present. Looks like this:

![screen shot 2019-01-31 at 20 43 32](https://user-images.githubusercontent.com/631691/52083997-ee03e480-2598-11e9-9ad0-396afe6192f4.png)
