### PR TITLE
[FEATURE] Pass doc descriptions through htmlbars

### DIFF
--- a/addon/components/api/x-class/template.hbs
+++ b/addon/components/api/x-class/template.hbs
@@ -1,7 +1,9 @@
 <h1 class='docs-h1' data-test-class-name>{{class.name}}</h1>
 
 {{! wrapping in a div seems to work around https://github.com/ember-learn/ember-cli-addon-docs/issues/7 }}
-<div data-test-class-description>{{{class.description}}}</div>
+<div data-test-class-description>
+  {{api/x-description class}}
+</div>
 
 {{#if (or class.exportType hasToggles)}}
   {{#api/x-meta-panel as |panel|}}

--- a/addon/components/api/x-component/template.hbs
+++ b/addon/components/api/x-component/template.hbs
@@ -1,7 +1,9 @@
 <h1 class='docs-h1' data-test-component-name>{{component.name}}</h1>
 
 {{! wrapping in a div seems to work around https://github.com/ember-learn/ember-cli-addon-docs/issues/7 }}
-<div data-test-component-name>{{{component.description}}}</div>
+<div data-test-component-name>
+  {{api/x-description component}}
+</div>
 
 {{#if hasToggles}}
   {{#api/x-meta-panel as |panel|}}

--- a/addon/components/api/x-description/component.js
+++ b/addon/components/api/x-description/component.js
@@ -1,0 +1,27 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+import { createTemplateFactory } from '@ember/template-factory';
+
+import layout from './template';
+
+export default Component.extend({
+  layout,
+  tagName: '',
+
+  item: null,
+
+  htmlbars: computed('item.htmlbars', function() {
+    let htmlbars = this.get('item.htmlbars');
+
+    if (htmlbars) {
+      return createTemplateFactory(JSON.parse(htmlbars));
+    }
+
+    return null;
+  }),
+}).reopenClass({
+
+  positionalParams: [ 'item' ]
+
+});

--- a/addon/components/api/x-description/template.hbs
+++ b/addon/components/api/x-description/template.hbs
@@ -1,0 +1,7 @@
+{{#if item}}
+  {{#if item.htmlbars}}
+    {{api/x-description layout=htmlbars}}
+  {{else}}
+    {{{item.description}}}
+  {{/if}}
+{{/if}}

--- a/addon/components/api/x-section/template.hbs
+++ b/addon/components/api/x-section/template.hbs
@@ -27,7 +27,7 @@
   </h3>
 
   <p data-test-item-description>
-    {{{item.description}}}
+    {{api/x-description item}}
   </p>
 
   {{#if (or item.exportType shouldDisplayParams)}}
@@ -51,7 +51,7 @@
               <tr data-test-item-param>
                 <td><span class="docs-font-mono docs-font-bold docs-border-r docs-border-grey-light docs-pr-2">{{param.name}}</span></td>
                 <td><span class="docs-font-mono docs-border-r docs-border-grey-light docs-px-2">{{param.type}}</span></td>
-                <td class="docs-pl-2">{{param.description}}</td>
+                <td class="docs-pl-2">{{api/x-description param}}</td>
               </tr>
             {{/each}}
           </tbody>

--- a/index.js
+++ b/index.js
@@ -187,6 +187,8 @@ module.exports = {
 
   postprocessTree(type, tree) {
     let parentAddon = this.parent.findAddonByName(this.parent.name());
+    let parentHtmlbars = this.parent.findAddonByName('ember-cli-htmlbars');
+
     if (!parentAddon || type !== 'all') { return tree; }
 
     let PluginRegistry = require('./lib/models/plugin-registry');
@@ -195,6 +197,7 @@ module.exports = {
 
     let project = this.project;
     let docsTrees = [];
+    let parentHtmlbarsOptions = parentHtmlbars.htmlbarsOptions();
 
     this.addonOptions.projects.main = this.addonOptions.projects.main || generateDefaultProject(parentAddon);
 
@@ -212,7 +215,8 @@ module.exports = {
       docsTrees.push(
         new DocsCompiler(docsGenerators, {
           name: projectName === 'main' ? parentAddon.name : projectName,
-          project
+          project,
+          templateCompiler: parentHtmlbarsOptions.templateCompiler
         })
       );
     }

--- a/lib/broccoli/docs-compiler.js
+++ b/lib/broccoli/docs-compiler.js
@@ -10,13 +10,19 @@ const Serializer = require('../serializers/main');
 const compileMarkdown = require('../utils/compile-markdown');
 const NavigationIndexGenerator = require('./docs-compiler/navigation-index-generator');
 
-function compileDescriptions(objects) {
+function compileDescriptions(objects, options = {}) {
+  let { templateCompiler } = options;
+
   if (!objects) { return; }
   if (!Array.isArray(objects)) { objects = [objects]; }
 
   for (let object of objects) {
     if (object.description) {
-      object.description = compileMarkdown(object.description);
+      object.description = compileMarkdown(object.description, { targetHandlebars: true });
+
+      if (templateCompiler) {
+        object.htmlbars = templateCompiler.precompile(object.description);
+      }
     }
   }
 }
@@ -32,11 +38,13 @@ const relationships = [
   'arguments'
 ];
 
-function eachRelationship(collection, fn) {
+function eachRelationship(collection, fn, options = {}) {
+  let { templateCompiler } = options;
+
   collection.forEach((item) => {
     relationships.forEach((key) => {
       if (item[key]) {
-        fn(item[key], key);
+        fn(item[key], key, { templateCompiler });
       }
     });
   });
@@ -63,13 +71,15 @@ function removeEmptyModules(modules) {
   });
 }
 
-function compileDocDescriptions(modules) {
-  modules.forEach(compileDescriptions);
+function compileDocDescriptions(modules, options = {}) {
+  let { templateCompiler } = options;
+
+  modules.forEach(module => compileDescriptions(module, { templateCompiler }));
 
   eachRelationship(modules, (relationship) => {
-    compileDescriptions(relationship);
+    compileDescriptions(relationship, { templateCompiler });
 
-    eachRelationship(relationship, compileDescriptions);
+    eachRelationship(relationship, compileDescriptions, { templateCompiler });
   });
 }
 
@@ -83,6 +93,7 @@ module.exports = class DocsCompiler extends CachingWriter {
 
     this.name = options.name;
     this.project = options.project;
+    this.templateCompiler = options.templateCompiler;
   }
 
   build() {
@@ -100,7 +111,9 @@ module.exports = class DocsCompiler extends CachingWriter {
 
     removeHiddenDocs(modules);
     removeEmptyModules(modules);
-    compileDocDescriptions(modules);
+    compileDocDescriptions(modules, {
+      templateCompiler: this.templateCompiler
+    });
 
     let project = {
       id: name,


### PR DESCRIPTION
This PR passes the api doc description through htmlbars compiler. This allows you to use any components that are accessible from the app. For my specific case, I was trying to pull a code snippet from elsewhere. But you can certainly get a running example in there.

@samselikoff This is a crude proof of concept PR. Let me know what you think and I can update the PR to be more robust.