### PR TITLE
support angle brackets with docs-demo component

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ module.exports = {
     includer.options.includeFileExtensionInSnippetNames = includer.options.includeFileExtensionInSnippetNames || false;
     includer.options.snippetSearchPaths = includer.options.snippetSearchPaths || ['tests/dummy/app'];
     includer.options.snippetRegexes = Object.assign({}, {
-      begin: /{{#(?:docs-snippet|demo.example)\sname=(?:"|')(\S+)(?:"|')/,
-      end: /{{\/(?:docs-snippet|demo.example)}}/,
+      begin: /(?:{{#|<)(?:docs-snippet|demo.example)\s@?name=(?:"|')(\S+)(?:"|')/,
+      end: /(?:{{|<)\/(?:docs-snippet|demo.example)(?:}}|>)/,
     }, includer.options.snippetRegexes);
     includer.options.includehighlightJS = false;
     includer.options.includeHighlightStyle = false;


### PR DESCRIPTION
The following snippet wasn't getting picked up by the original regex:
```hbs
<DocsDemo as |demo|>
  <demo.example @name='button-example.hbs'>
    <MyButton>
      Click Me
    </MyButton>
  </demo.example>

  <demo.snippet @name='button-example.hbs'/>
</DocsDemo>
```

This shouldn't break existing classic component invocation of `docs-demo`.