### PR TITLE
Update ember-concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-tailwind": "^0.6.2",
     "ember-code-snippet": "^2.4.0",
     "ember-component-css": "^0.6.7",
-    "ember-concurrency": "^0.8.21",
+    "ember-concurrency": "^0.9.0",
     "ember-data": "2.x - 3.x",
     "ember-fetch": "^6.2.0",
     "ember-fetch-adapter": "^0.4.3",


### PR DESCRIPTION
There've been some breaking changes coming down the pipe to Ember APIs that e-c uses, we need to update it to make sure our users can update. `e-c` itself shouldn't have any breaking API changes.