### PR TITLE
Don't blow away the host's auto-import config

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,6 @@ module.exports = {
     includer.options.includehighlightJS = false;
     includer.options.includeHighlightStyle = false;
     includer.options.snippetExtensions = ['js', 'css', 'scss', 'hbs', 'md', 'text', 'json', 'handlebars', 'htmlbars', 'html', 'diff'];
-    includer.options.autoImport = {
-      exclude: [ 'qunit' ]
-    };
 
     // This must come after we add our own options above, or else other addons won't see them.
     this._super.included.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.7.0",
     "mocha": "^6.0.2",
-    "qunit": "^2.6.2",
     "qunit-dom": "^0.8.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10448,7 +10448,7 @@ qunit-dom@^0.8.4:
     broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^3.0.1"
 
-qunit@^2.6.2, qunit@~2.6.0:
+qunit@~2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.6.2.tgz#551210c5cf857258a4fe39a7fe15d9e14dfef22c"
   integrity sha512-PHbKulmd4rrDhFto7iHicIstDTX7oMRvAcI7loHstvU8J7AOGwzcchONmy+EG4KU8HDk0K90o7vO0GhlYyKlOg==


### PR DESCRIPTION
Right now we trash any configuration the host app has for ember-auto-import to avoid having it try and include `qunit` in our own tests. This isn't necessary now that we're using mocha for node tests and don't need `qunit` in our dependencies, but this config should have been in our `ember-cli-build.js` to begin with so it wouldn't interfere with the host.