### PR TITLE
Remove beta from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,5 +77,4 @@ jobs:
           repo: ember-learn/ember-cli-addon-docs
 
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary


### PR DESCRIPTION
This PR doesn't allow addon-docs to fail in Ember beta.

The default config for ember addons [will not allow beta to fail]( https://github.com/ember-cli/ember-addon-output/blob/master/.travis.yml#L31). Since addons are the most likely consumer of addon docs it's possible that they could pull in a version of addon docs that fails in Ember beta (and potentially breaks their travis builds).

Related: https://github.com/ember-learn/ember-cli-addon-docs/pull/363