### PR TITLE
Upgrade ember-responsive to fix broken tests on ember beta & canary builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-href-to": "^1.15.1",
     "ember-keyboard": "^4.0.0",
     "ember-modal-dialog": "3.0.0-beta.3",
-    "ember-responsive": "^3.0.0",
+    "ember-responsive": "^3.0.1",
     "ember-router-generator": "^1.2.3",
     "ember-router-scroll": "^1.0.0",
     "ember-svg-jar": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,10 +5199,10 @@ ember-resolver@^5.0.1:
     ember-cli-version-checker "^2.0.0"
     resolve "^1.3.3"
 
-ember-responsive@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ember-responsive/-/ember-responsive-3.0.0.tgz#03791da324299a8c8cb461e541a5e1aeca887881"
-  integrity sha512-5JQ+REBu37M7NNDJOnTjzp5eQzg4cX7VtPcD19V3nBcntRuDwf7N6TndLxmw4Kt3JXuzQL4PkDE2SgVKuNTdWQ==
+ember-responsive@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-responsive/-/ember-responsive-3.0.1.tgz#52eac29ff9ab57e4912f65354056aee1f132c63c"
+  integrity sha512-diHQ09KL1SNM0jOwW6iGailh0MhcbdBP5JIQc/jiIijYm/pNe0LRGnnYvM3FK5RQ6XeDg87rLx0shLyCy0HpTg==
   dependencies:
     ember-cli-babel "^6.6.0"
 


### PR DESCRIPTION
Actually does what it says on #363. ember-responsive had the fix in 3.0.1 which they didn't publish to npm until yesterday (#363 updated it to 3.0.0 😅)