### PR TITLE
WIP: Try to get multi package docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ module.exports = {
 
     const packageTrees = new MergeTrees(
       this.addonOptions.packages.map(
-        pkg => new Funnel(path.resolve(pkg))
+        pkg => new Funnel(path.join(parentAddon.root, 'node_modules', pkg), { destDir: pkg })
       )
     );
 

--- a/index.js
+++ b/index.js
@@ -191,13 +191,15 @@ module.exports = {
     let DocsCompiler = require('./lib/broccoli/docs-compiler');
     let SearchIndexer = require('./lib/broccoli/search-indexer');
 
+
     let project = this.project;
     let docsTrees = [];
 
     this.addonOptions.projects.main = this.addonOptions.projects.main || generateDefaultProject(parentAddon);
 
+    const packages = this.addonOptions.packages || []
     const packageTrees = new MergeTrees(
-      this.addonOptions.packages.map(
+      packages.map(
         pkg => new Funnel(path.join(parentAddon.root, 'node_modules', pkg), { destDir: pkg })
       )
     );

--- a/index.js
+++ b/index.js
@@ -196,6 +196,12 @@ module.exports = {
 
     this.addonOptions.projects.main = this.addonOptions.projects.main || generateDefaultProject(parentAddon);
 
+    const packageTrees = new MergeTrees(
+      this.addonOptions.packages.map(
+        pkg => new Funnel(path.resolve(pkg))
+      )
+    );
+
     for (let projectName in this.addonOptions.projects) {
       let addonSourceTree = this.addonOptions.projects[projectName];
 
@@ -204,7 +210,8 @@ module.exports = {
       let docsGenerators = pluginRegistry.createDocsGenerators(addonSourceTree, {
         destDir: 'docs',
         project,
-        parentAddon
+        parentAddon,
+        packageTrees,
       });
 
       docsTrees.push(

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ module.exports = {
     const packages = this.addonOptions.packages || []
     const packageTrees = new MergeTrees(
       packages.map(
-        pkg => new Funnel(pkg, { destDir: pkg })
+        pkg => new Funnel(pkg, { destDir: pkg.replace(/node_modules\//, '') })
       )
     );
 

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ module.exports = {
     const packages = this.addonOptions.packages || []
     const packageTrees = new MergeTrees(
       packages.map(
-        pkg => new Funnel(path.join(parentAddon.root, 'node_modules', pkg), { destDir: pkg })
+        pkg => new Funnel(pkg, { destDir: pkg })
       )
     );
 


### PR DESCRIPTION
Adds possibility to specify `packages` on the addon and include it in the documentation.

Still have to grasp on some things and find a better way or a different naming to resolve packages that are in addon's `node_modules` (not in a monorepo).

(don't want to keep `node_modules` hardcoded there)

Feedback is welcome