### PR TITLE
`docs/api/item` route – fix for nested components

### DIFF
--- a/addon/routes/docs/api/item.js
+++ b/addon/routes/docs/api/item.js
@@ -18,7 +18,7 @@ export default Route.extend({
     } else {
       // Create a regex that will match modules by either the path, or the
       // pod-path (/component, /route, etc)
-      let type = path.match(/^(.*)s\//)[1];
+      let type = path.match(/^(\w*)s\//)[1];
       let pathRegex = new RegExp(`${path}(/${type})?$`);
 
       let modules = this.store.peekAll('module');


### PR DESCRIPTION
I've discovered that nested components can cause to break `addon/routes/docs/api/item.js#model()`. With the example of `path="components/sub-components/foo"` determining the type now returns:
```js
let type = path.match(/^(.*)s\//)[1] // "components/sub-component"
```
While the following code would return the correct value:
```js
let type = path.match(/^(\w*)s\//)[1] // "component"
```

I'm not sure that this doesn't break anything, though.