### PR TITLE
Fix scoped packages bug when nav items are generated

### DIFF
--- a/lib/broccoli/docs-compiler/navigation-index-generator.js
+++ b/lib/broccoli/docs-compiler/navigation-index-generator.js
@@ -52,11 +52,19 @@ module.exports = class NavigationIndexGenerator {
     return resolvedType || 'modules';
   }
 
-  _resolvedTypeForModule(module) {
-    let [ , type ] = module.file.split('/');
+_resolvedTypeForModule(module) {
+  let path = module.file.split('/');
 
-    return RESOLVED_TYPES.includes(type) && type;
+  // By default we assume that the type is at index 1
+  let type = path[1];
+
+  // If the module is a scoped package, then the type will be at index 2
+  if (path[0].charAt(0) === '@') {
+    type = path[2];
   }
+
+  return RESOLVED_TYPES.includes(type) && type;
+}
 
   _isResolvedType(module) {
     return this._resolvedTypeForModule(module);


### PR DESCRIPTION
When working in an addon with a scoped package name (eg: @scope-name/package-name), the "API REFERENCE", "Components" navigation section is incorrectly generated (it shows Class Name). The expected outcome is {{component-name}}.

The link generated is also messed up:
Expected: https://user-or-org.github.io/repo-name/docs/api/components/component-name
Actual: https://user-or-org.github.io/repo-name/docs/api/modules/@scope-name/package-name/components/component-name~Class%20Name

This is because of how ember-addon-docs assumes the root of the package. 

Fixes #374 