### PR TITLE
Use "Escape" key to dismiss Keyboard Shortcuts modal

### DIFF
--- a/addon/components/docs-keyboard-shortcuts/component.js
+++ b/addon/components/docs-keyboard-shortcuts/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { on } from '@ember/object/evented';
-import { later } from "@ember/runloop";
+import { later } from '@ember/runloop';
 import layout from './template';
 import { EKMixin, keyUp } from 'ember-keyboard';
 import { inject as service } from '@ember/service';
@@ -52,6 +52,12 @@ export default Component.extend(EKMixin, {
   toggleKeyboardShortcuts: on(keyUp('shift+Slash'), function() {
     if (!formElementHasFocus()) {
       this.toggleProperty('isShowingKeyboardShortcuts');
+    }
+  }),
+
+  hideKeyboardShortcuts: on(keyUp('Escape'), function() {
+    if (!formElementHasFocus() && this.get('isShowingKeyboardShortcuts')) {
+      this.set('isShowingKeyboardShortcuts', false);
     }
   }),
 

--- a/addon/components/docs-keyboard-shortcuts/template.hbs
+++ b/addon/components/docs-keyboard-shortcuts/template.hbs
@@ -49,6 +49,14 @@
               Bring up this help dialog
             </td>
           </tr>
+          <tr>
+            <td>
+              <code class='docs__keyboard-key'>esc</code>
+            </td>
+            <td>
+              Hide this help dialog
+            </td>
+          </tr>
 
           <tr>
             <th></th>


### PR DESCRIPTION
Adds a keyUp listener for 'Escape' that dismisses the shortcuts modal
when invoked.

Also fixes an unrelated inconsistency in quote style in the
keyboard-shortcuts component.

<kbd>Esc</kbd> seems to be a common shortcut for other modals (e.g. [bootstrap](https://getbootstrap.com/docs/4.0/components/modal/#options) and [ember-modal-dialog](https://github.com/yapplabs/ember-modal-dialog#keyboard-shortcuts)).