### PR TITLE
enhancement: Add config options to indicate the file extensions that ember-code-snippet needs to use

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,27 @@ module.exports = {
     }, includer.options.snippetRegexes);
     includer.options.includehighlightJS = false;
     includer.options.includeHighlightStyle = false;
-    includer.options.snippetExtensions = ['js', 'css', 'scss', 'hbs', 'md', 'text', 'json', 'handlebars', 'htmlbars', 'html', 'diff'];
+
+    let snippetExtensions = includer.options.snippetExtensions;
+
+    if (!Array.isArray(includer.options.snippetExtensions)) {
+      snippetExtensions = [
+        'ts',
+        'js',
+        'css',
+        'scss',
+        'hbs',
+        'md',
+        'text',
+        'json',
+        'handlebars',
+        'htmlbars',
+        'html',
+        'diff'
+      ];
+    }
+
+    includer.options.snippetExtensions = snippetExtensions;
 
     // This must come after we add our own options above, or else other addons won't see them.
     this._super.included.apply(this, arguments);

--- a/tests/dummy/app/pods/docs/build-options/template.md
+++ b/tests/dummy/app/pods/docs/build-options/template.md
@@ -1,0 +1,35 @@
+# Build options
+
+To override the default configuration of the addon, use the following options in your `ember-cli-build.js`.
+
+## snippetExtensions
+
+Override the default file extensions where [ember-code-snippet](https://github.com/ef4/ember-code-snippet) looks for snippets.
+
+### Default:
+
+`['js','ts','coffee','html','hbs','md','css','sass','scss','less','emblem','yaml']`
+
+### How to use it
+
+{{#docs-snippet name='build-options-snippet-extensions.js' title='app/ember-cli-build.js'}}
+  /* global require, module */
+  const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+  module.exports = function(defaults) {
+    let app = new EmberAddon(defaults, {
+      // More config options of your app here
+
+      snippetExtensions: ['js','ts','coffee','html','hbs','md','css','sass','scss','less','emblem','yaml'],
+
+      // More config options of your app here
+    });
+
+    return app.toTree();
+  };
+{{/docs-snippet}}
+
+
+
+
+

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -6,6 +6,7 @@
     {{nav.item 'Usage' 'docs.usage'}}
     {{nav.item 'Quickstart' 'docs.quickstart'}}
     {{nav.item 'Patterns' 'docs.patterns'}}
+    {{nav.item 'Build options' 'docs.build-options'}}
     {{nav.item 'Deploying' 'docs.deploying'}}
 
     {{nav.section 'Components'}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route('usage');
     this.route('quickstart');
     this.route('patterns');
+    this.route('build-options');
     this.route('deploying');
 
     this.route('components', function() {


### PR DESCRIPTION
## Description

Since this PR: https://github.com/ef4/ember-code-snippet/pull/59/files it is possible to indicate the extensions to look for snippets. This PR just add the option to use the functionality.

I added a new section to the documentation to let people know that this new option exists.

![Screenshot 2019-10-13 at 20 01 59](https://user-images.githubusercontent.com/344518/66719778-5677b680-edf4-11e9-8671-55ef6308d9c5.png)

