### PR TITLE
dependabot: Add a config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+    automerged_updates:
+      - match:
+          update_type: "in_range"
+    version_requirement_updates: "auto"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,10 +2,13 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "daily"
     default_labels:
       - "dependencies"
     automerged_updates:
       - match:
           update_type: "in_range"
+    ignored_updates:
+      - match:
+          dependency_name: "ember-cli"      
     version_requirement_updates: "auto"


### PR DESCRIPTION
#### Description

Would you accept a Dependabot config to automate dependencies upgrade?

#### Details

This config runs dependabot **on a weekly basis** (not to be too verbose). It can also be run on a montly basis if you prefer.

This config should also **auto-merge in-range updates**. To enable that feature, you'll have to visit https://app.dependabot.com/accounts/ember-cli-addon-docs/settings and tick the box `Allow auto-merging to be enabled on projects`.

To enable **squash and merge** for dependabot PRs, you'll have to untick the box `Create a merge commit if a PR is merged by Dependabot`.

With the `version_requirement_updates: auto` option, Dependabot should:
- increase versions in the `devDependencies`
- widen ranges in the `dependencies`