### PR TITLE
Refactor route anchor jump system

### DIFF
--- a/addon/initializers/route-anchor-jump.js
+++ b/addon/initializers/route-anchor-jump.js
@@ -1,11 +1,9 @@
 import Route from '@ember/routing/route';
 import { scheduleOnce } from '@ember/runloop';
 
-export function initialize() {
-  Route.reopen({
-    afterModel() {
-      this._super(...arguments);
-
+Route.reopen({
+  afterModel() {
+    if (typeof location !== 'undefined') {
       const { hash } = location;
       if (hash && hash.length) {
         scheduleOnce('afterRender', null, () => {
@@ -16,9 +14,13 @@ export function initialize() {
         });
       }
     }
-  })
-}
+
+    return this._super(...arguments);
+  }
+});
+
+export function initialize() {}
 
 export default {
-  initialize
+  initialize,
 };


### PR DESCRIPTION
* avoid making reopen inside `initialize` (it should only be done once **ever** not once per application)
* avoid destructuring from `location` when it is not defined (e.g. FastBoot contexts)
* ensure that the super result is properly returned (previously we would drop any promises returned from afterModel 😱)

Fixes #417 