### PR TITLE
Change scheduleOnce to schedule

### DIFF
--- a/addon/initializers/route-anchor-jump.js
+++ b/addon/initializers/route-anchor-jump.js
@@ -1,12 +1,12 @@
 import Route from '@ember/routing/route';
-import { scheduleOnce } from '@ember/runloop';
+import { schedule } from '@ember/runloop';
 
 Route.reopen({
   afterModel() {
     if (typeof location !== 'undefined') {
       const { hash } = location;
       if (hash && hash.length) {
-        scheduleOnce('afterRender', null, () => {
+        schedule('afterRender', null, () => {
           const anchor = document.querySelector(`a[href="${hash}"`);
           if (anchor) {
             anchor.scrollIntoView();


### PR DESCRIPTION
Using `scheduleOnce` with an anonymous function [doesn't actually schedule only once](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md), since a new function is created on every invocation. This PR just changes to use `schedule`, which I believe is fine in this case.