### PR TITLE
rootURL: replace backslashes with forward slashes, fixes #427

### DIFF
--- a/lib/deploy/plugin.js
+++ b/lib/deploy/plugin.js
@@ -151,7 +151,7 @@ module.exports = class AddonDocsDeployPlugin {
 
   _updateIndexContents(context, stagingDirectory, appRoot, deployVersion) {
     let indexPath = `${stagingDirectory}/${appRoot}/index.html`;
-    let rootURL = [this._getRootURL(), appRoot].filter(Boolean).join('/');
+    let rootURL = [this._getRootURL(), appRoot].filter(Boolean).join('/').replace(/\\/g, '/');
     let addonDocsRootURL = rootURL === '' ? '/' : `/${rootURL}/`;
     let contents = fs.readFileSync(indexPath, 'utf-8');
     let encodedVersion = encodeURIComponent(JSON.stringify(deployVersion));


### PR DESCRIPTION
This might be not the right place to do the replacement, but it does the thing and unblocks my deploys.