### PR TITLE
Fix copy snippet button

### DIFF
--- a/addon/components/docs-snippet/component.js
+++ b/addon/components/docs-snippet/component.js
@@ -81,7 +81,7 @@ export default Component.extend({
       name += '.hbs';
     }
 
-    let snippet = require(config.modulePrefix + "/snippets")[name] || "";
+    let snippet = require(config.modulePrefix + "/snippets").default[name] || "";
 
     return this._unindent(
       snippet


### PR DESCRIPTION
[This change](https://github.com/ember-learn/ember-cli-addon-docs/commit/5fb1cc8093ef530610345aa3938f2133112e91dd#diff-f7fa78c2855306dcc677ce08403e4a7bR84-R87) broke _Copy button_ and [this added test](https://github.com/ember-learn/ember-cli-addon-docs/pull/421/files#diff-e9530505b3b89edc49ce62e319dd4131) broke the tests.