### PR TITLE
Support non-block `<DocsSnippet>` invocation

### DIFF
--- a/addon/components/docs-snippet/template.hbs
+++ b/addon/components/docs-snippet/template.hbs
@@ -14,7 +14,7 @@
     docs-relative docs-subpixel-antialiased
     {{if title "docs-rounded-b" "docs-rounded"}}
   "
-  data-test-id={{name}}
+  data-test-id={{or data-test-id name}}
 >
   {{#with (get-code-snippet name unindent=unindent) as |snippet|}}
     {{#if showCopy}}

--- a/index.js
+++ b/index.js
@@ -128,10 +128,19 @@ module.exports = {
         includer.options.snippetSearchPaths = ['tests/dummy/app'];
       }
     }
-    includer.options.snippetRegexes = Object.assign({}, {
-      begin: /(?:{{#|<)(?:DocsSnippet|docs-snippet|demo\.example)\s@?name=['"](\S*)['"]/,
-      end: /(?:{{|<)\/(?:DocsSnippet|docs-snippet|demo\.example)(?:}}|>)/,
-    }, includer.options.snippetRegexes);
+
+    if (!includer.options.snippetRegexes) {
+      includer.options.snippetRegexes = [
+        {
+          begin: /{{#(?:docs-snippet|demo\.example)\sname=['"](\S*)['"]/,
+          end: /{{\/(?:docs-snippet|demo\.example)}}/,
+        },
+        {
+          begin: /<(?:DocsSnippet|demo\.example)\s@name=['"](\S*)['"][^/]*>/,
+          end: /<\/(?:DocsSnippet|demo\.example)>/
+        }
+      ];
+    }
 
     let snippetExtensions = includer.options.snippetExtensions;
 

--- a/test-apps/new-addon/tests/acceptance/snippets-test.js
+++ b/test-apps/new-addon/tests/acceptance/snippets-test.js
@@ -2,13 +2,18 @@ import { module, test } from 'qunit';
 import { visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-const snippetIds = ['your-snippet-name.hbs', 'your-angle-bracket-snippet-name.hbs'];
+const snippetIds = [
+  'your-snippet-name.hbs',
+  'your-angle-bracket-snippet-name.hbs',
+  'standalone-curlies',
+  'standalone-angle-brackets'
+];
 
 module('Acceptance | snippets', function(hooks) {
   setupApplicationTest(hooks);
 
   test('snippets support both classic & angle bracket invocation', async function(assert) {
-    assert.expect(13);
+    assert.expect(17);
 
     await visit('/snippets');
 

--- a/test-apps/new-addon/tests/dummy/app/templates/snippets.hbs
+++ b/test-apps/new-addon/tests/dummy/app/templates/snippets.hbs
@@ -20,6 +20,10 @@
   </div>
 </DocsSnippet>
 
+{{docs-snippet name="your-snippet-name.hbs" data-test-id="standalone-curlies"}}
+
+<DocsSnippet @name="your-angle-bracket-snippet-name.hbs" @data-test-id="standalone-angle-brackets" />
+
 {{#docs-demo data-test-id="docs-demo-basic.hbs" as |demo|}}
   {{#demo.example name="docs-demo-basic.hbs"}}
     <p>I am a <strong>handlebars</strong> template!</p>


### PR DESCRIPTION
In #421 we landed support for using angle-bracket invocation with `<DocsDemo>` and `<DocsSnippet>`, but it unfortunately didn't handle non-block usage that referenced a snippet defined elsewhere, e.g.:

```hbs
<DocsSnippet @name="my-snippet.hbs" />
```

Code like ☝️ would wind up capturing everything after that in the file as "my-snippet.hbs" instead of honoring the `/>`.