### PR TITLE
Fix docs heading styles due to Tailwind's v1 preflight

### DIFF
--- a/addon/styles/components/_docs-md.scss
+++ b/addon/styles/components/_docs-md.scss
@@ -13,14 +13,14 @@
 .docs-h2,
 .docs-md__h2 a,
 .docs-h2 a {
-  @apply docs-pt-8 docs-mb-4 docs-text-grey-darkest docs-leading-tight docs-no-underline;
+  @apply docs-pt-8 docs-mb-4 docs-text-grey-darkest docs-text-large-4 docs-font-bold docs-leading-tight docs-no-underline;
 }
 
 .docs-md__h3,
 .docs-h3,
 .docs-md__h3 a,
 .docs-h3 a {
-  @apply docs-pt-4 docs-mb-1 docs-text-grey-darkest docs-leading-normal docs-no-underline;
+  @apply docs-pt-4 docs-mb-1 docs-text-grey-darkest docs-text-large-3 docs-font-bold docs-leading-normal docs-no-underline;
 }
 
 .docs-md p {


### PR DESCRIPTION
## Before:
<img width="782" alt="Screen Shot 2020-01-03 at 10 06 35 AM" src="https://user-images.githubusercontent.com/230476/71740338-ce141b00-2e10-11ea-840c-8330badac596.png">


## After
<img width="793" alt="Screen Shot 2020-01-03 at 10 06 50 AM" src="https://user-images.githubusercontent.com/230476/71740349-d2d8cf00-2e10-11ea-85b5-98bb37391817.png">
