### PR TITLE
tip: Visual Studio Code addon-docs integration

### DIFF
--- a/tests/dummy/app/pods/docs/usage/template.md
+++ b/tests/dummy/app/pods/docs/usage/template.md
@@ -15,7 +15,7 @@ ember install ember-cli-addon-docs
 
 ## Visual Studio Code integration
 
-To get AddonDocs autocomplete in your projects, install [els-addon-docs](https://github.com/lifeart/els-addon-docs) for [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) as `devDependency` for your project. 
+To get AddonDocs autocomplete in your projects, install [els-addon-docs](https://github.com/lifeart/els-addon-docs) for [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) as a `devDependency` for your project. 
 
 <!-- ## New addons
 

--- a/tests/dummy/app/pods/docs/usage/template.md
+++ b/tests/dummy/app/pods/docs/usage/template.md
@@ -13,6 +13,10 @@ Note that your addon can still support older versions of Ember – it's just th
 ember install ember-cli-addon-docs
 ```
 
+## Visual Studio Code integration
+
+To get AddonDocs autocomplete in your projects, install [els-addon-docs](https://github.com/lifeart/els-addon-docs) for [Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) as `devDependency` for your project. 
+
 <!-- ## New addons
 
 


### PR DESCRIPTION
Any developer can get autocomplete and documentation tips for addons used in projects if addons has addon-docs documentation.

https://github.com/lifeart/els-addon-docs