### PR TITLE
fix deprecation ember-data:default-serializer

### DIFF
--- a/addon/serializers/class.js
+++ b/addon/serializers/class.js
@@ -1,0 +1,1 @@
+export { default } from './-addon-docs';

--- a/addon/serializers/component.js
+++ b/addon/serializers/component.js
@@ -1,0 +1,1 @@
+export { default } from './-addon-docs';

--- a/addon/serializers/module.js
+++ b/addon/serializers/module.js
@@ -1,0 +1,1 @@
+export { default } from './-addon-docs';

--- a/addon/serializers/project.js
+++ b/addon/serializers/project.js
@@ -1,0 +1,1 @@
+export { default } from './-addon-docs';


### PR DESCRIPTION
by rexporting -addon-docs serializer
see https://deprecations.emberjs.com/ember-data/v3.x#toc_ember-data:default-serializers

fixes https://github.com/ember-learn/ember-cli-addon-docs/issues/439