### PR TITLE
fix array helper clobbering built in helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,34 @@ module.exports = {
 
     includer.options.snippetExtensions = snippetExtensions;
 
+    const VersionChecker = require('ember-cli-version-checker');
+    const checker = new VersionChecker(this.project);
+    const ember = checker.forEmber();
+
+    if (ember.gte('3.8.0')) {
+      // array helper is built into ember as of 3.8.
+      // ember 3.17 starts erroring when overwritting built in helpers
+
+      // exclude from ember-cli-addon-docs
+      this.options['ember-composable-helpers'] = {
+        except: ['array']
+      };
+
+      // exclude from the app using ember-cli-addon-docs
+      if (!includer.options['ember-composable-helpers']) {
+        includer.options['ember-composable-helpers'] = {};
+      }
+
+      const echOptions = includer.options['ember-composable-helpers'];
+      if (!echOptions.only) {
+        if (!echOptions.except) {
+          echOptions.except = ['array'];
+        } else if (echOptions.except.indexOf('array') === -1) {
+          echOptions.except.push('array');
+        }
+      }
+    }
+
     // This must come after we add our own options above, or else other addons won't see them.
     this._super.included.apply(this, arguments);
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-sass": "10.0.1",
     "ember-cli-string-helpers": "^4.0.5",
     "ember-cli-string-utils": "^1.1.0",
+    "ember-cli-version-checker": "^3.1.0",
     "ember-code-snippet": "^3.0.0",
     "ember-component-css": "^0.7.4",
     "ember-composable-helpers": "^2.3.1",
@@ -141,6 +142,7 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-htmlbars",
+      "ember-composable-helpers",
       "ember-svg-jar",
       "ember-code-snippet"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5499,7 +5499,7 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
+ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.0, ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   integrity sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==


### PR DESCRIPTION
The version of ember-composable-helpers currently being used provides an array helper.
ember@next has started erroring when it encounters built in helpers being clobbered.

ember-composable-helpers@3 has removed the array helper and upgraded to octane.
As an alternative to the commit, we could try to get a new version of ember-composable-helpers@2 cut that excludes the array helper for ember <= 3.8.