### PR TITLE
Use section instead of item for Introduction

### DIFF
--- a/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/quickstart/template.md
@@ -91,7 +91,7 @@ The `docs` route is the entry point for your guides and API docs. Create a new `
 {{#docs-snippet name="quickstart-skeleton.hbs" language="htmlbars" title="tests/dummy/app/templates/docs.hbs"}}
   {{#docs-viewer as |viewer|}}
     {{#viewer.nav as |nav|}}
-      {{nav.section "Introduction" "docs.index"}}
+      {{nav.section "Introduction"}}
     {{/viewer.nav}}
 
     {{#viewer.main}}

--- a/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/quickstart/template.md
@@ -91,7 +91,7 @@ The `docs` route is the entry point for your guides and API docs. Create a new `
 {{#docs-snippet name="quickstart-skeleton.hbs" language="htmlbars" title="tests/dummy/app/templates/docs.hbs"}}
   {{#docs-viewer as |viewer|}}
     {{#viewer.nav as |nav|}}
-      {{nav.item "Introduction" "docs.index"}}
+      {{nav.section "Introduction" "docs.index"}}
     {{/viewer.nav}}
 
     {{#viewer.main}}


### PR DESCRIPTION
This reflects how the addon-docs site itself is structured and is also consistent with the fact that the Quickstart guide later asks you to generate an index page, which would get added as a sub-item in the nav under the Introduction section. It's also convenient, because it subtly introduces the concept of a nav section, which isn't covered anywhere else in the Quickstart.