### PR TITLE
Upgrade ember-composable-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-version-checker": "^3.1.3",
     "ember-code-snippet": "^3.0.0",
     "ember-component-css": "^0.7.4",
-    "ember-composable-helpers": "^2.4.0",
+    "ember-composable-helpers": "^4.0.0",
     "ember-concurrency": "^0.9.0 || ^0.10.0 || ^1.0.0",
     "ember-data": "2.x - 3.x",
     "ember-fetch": "^6.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6822,14 +6822,14 @@ ember-component-css@^0.7.4:
     rsvp "^4.8.4"
     walk-sync "^1.0.1"
 
-ember-composable-helpers@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-2.4.0.tgz#024bd6a8c338cc9cdf10f1141b119b8f72de205f"
-  integrity sha512-91ZqFnNG1EDL3WzxXWTgAy6EonPS7htWHletI5SOw5ezEzKbt6EGNBwT6QPhwariugtR8LEfYNQ9lXEiCZrX1w==
+ember-composable-helpers@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.0.0.tgz#856cf4d86f2245feeb69ae1684e5a58ec742fcca"
+  integrity sha512-SF/mrLEoB0W7Mf+G2ye13K1I9IgkUaeFaWDVDTRzSAX7xmjBiPepLsqZvNJ1WcXimFTodGffku4AbQ2D0t+/2Q==
   dependencies:
     "@babel/core" "^7.0.0"
     broccoli-funnel "2.0.1"
-    ember-cli-babel "^7.1.0"
+    ember-cli-babel "^7.11.1"
     resolve "^1.10.0"
 
 "ember-concurrency@^0.9.0 || ^0.10.0 || ^1.0.0":


### PR DESCRIPTION
This fixes the error `You attempted to overwrite the built-in helper "array" which is not allowed`