### PR TITLE
Minimum 3.x series for ember-data addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "peerDependencies": {
-    "ember-data": "3.x",
+    "ember-data": ">= 3.0.0",
     "ember-fetch": "^8.0.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-component-css": "^0.7.4",
-    "ember-data": "2.x - 3.x",
+    "ember-data": "~3.21.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
@@ -143,7 +143,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "peerDependencies": {
-    "ember-data": "2.x - 3.x",
+    "ember-data": "3.x",
     "ember-fetch": "^8.0.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,7 +6591,7 @@ ember-composable-helpers@^4.2.2:
     ember-compatibility-helpers "^1.2.0"
     ember-maybe-import-regenerator "^0.1.6"
 
-"ember-data@2.x - 3.x":
+ember-data@~3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.21.0.tgz#2074f2076fc9a1121af6935798ae2e37453bc0ef"
   integrity sha512-p7hI/oDREkysgt5M2Y9q+lO3qvHri7TF42JI76+fRl3LeacDnJsZzqPnolBNOs8xOEJEf4cH1IDuipwI7+soJw==


### PR DESCRIPTION
ref #552 

I am unsure if peer dependencies is a strict versio or loose range.  Might be worthwhile to make it `3.x - and above` if so.