### PR TITLE
Add test for both ember-concurrency v1 and v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=ember-classic
+    - env: EMBER_TRY_SCENARIO=ember-concurrency-1.x
+    - env: EMBER_TRY_SCENARIO=ember-concurrency-2.x
 
     - stage: deploy
       if: (branch = master OR tag IS present) AND type = push

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -73,6 +73,22 @@ module.exports = async function() {
             edition: 'classic'
           }
         }
+      },
+      {
+        name: 'ember-concurrency-1.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^1.3.0'
+          }
+        }
+      },
+      {
+        name: 'ember-concurrency-2.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^2.0.0-beta.1'
+          }
+        }
       }
     ]
   };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-cli-version-checker": "^3.1.3",
     "ember-code-snippet": "^3.0.0",
     "ember-composable-helpers": "^4.2.2",
-    "ember-concurrency": "^0.9.0 || ^0.10.0 || ^1.0.0",
+    "ember-concurrency": ">=0.9.0 <3",
     "ember-fetch": "^8.0.2",
     "ember-get-config": "^0.2.4",
     "ember-href-to": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,10 +6589,10 @@ ember-composable-helpers@^4.2.2:
     ember-cli-babel "^7.11.1"
     resolve "^1.10.0"
 
-"ember-concurrency@^0.9.0 || ^0.10.0 || ^1.0.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.2.1.tgz#54fb234579638c5c43d4153a4e14567fe2b2e325"
-  integrity sha512-6zlK3BndPPZlSVWq6xBohwobpDKrI58nMMDfD8OqjoeBwnaznuyVHJqDZ46NRJrvSqYX6R96XBBVpDGCCcbK+w==
+"ember-concurrency@>=0.9.0 <3":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.3.0.tgz#66f90fb792687470bcee1172adc0ebf33f5e8b9c"
+  integrity sha512-DwGlfWFpYyAkTwsedlEtK4t1DznJSculAW6Vq5S1C0shVPc5b6tTpHB2FFYisannSYkm+wpm1f1Pd40qiNPtOQ==
   dependencies:
     ember-cli-babel "^7.7.3"
     ember-compatibility-helpers "^1.2.0"


### PR DESCRIPTION
We've just released ember-concurrency 2.0.0-beta.1. It's a largely API-compatible re-engineering of ember-concurrency's internals to support tracked properties and decouple from Ember (shedding EmberObject, etc.). As a popular library which depends on ember-concurrency, it would be nice for `ember-cli-addon-docs` to support both 1.x and 2.x versions concurrently so that folks can upgrade the version of ember-concurrency in their applications at their leisure without waiting for all the add-ons they use to switch over to a newer version (and risk leaving folks who cannot upgrade yet behind.)

This PR adds some scenarios to ember-try to enable testing against both major releases and relaxes the version restriction.

The build fails for beta and canary, but does not appear related to these changes.