### PR TITLE
Import htmlSafe from `@ember/template`

### DIFF
--- a/addon/helpers/type-signature.js
+++ b/addon/helpers/type-signature.js
@@ -1,6 +1,6 @@
 import { assert } from '@ember/debug';
 import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 function escape(text) {
   return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');

--- a/addon/utils/compile-markdown.js
+++ b/addon/utils/compile-markdown.js
@@ -81,7 +81,7 @@ export function highlightCode(code, lang) {
   ```js
   import Component from '@ember/component';
   import compileMarkdown from 'ember-cli-addon-docs/utils/compile-markdown';
-  import { htmlSafe } from '@ember/string';
+  import { htmlSafe } from '@ember/template';
 
   export default Component.extend({
     htmlBody: computed('post.body', function() {

--- a/test-apps/new-addon/tests/dummy/app/controllers/route-using-compile-markdown.js
+++ b/test-apps/new-addon/tests/dummy/app/controllers/route-using-compile-markdown.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import compileMarkdown from 'ember-cli-addon-docs/utils/compile-markdown';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export default Controller.extend({
 


### PR DESCRIPTION
I noticed the deprecation messages when importing htmlSafe from `@ember/string`. The messages are still there due to t[his issue though](https://github.com/emberjs/ember.js/issues/19393). But that should be resolved in the next ember-source patch release.