### PR TITLE
fix: display of import path

### DIFF
--- a/addon/components/api/x-class/template.hbs
+++ b/addon/components/api/x-class/template.hbs
@@ -3,7 +3,7 @@
 {{! wrapping in a div seems to work around https://github.com/ember-learn/ember-cli-addon-docs/issues/7 }}
 <div data-test-class-description>{{{@class.description}}}</div>
 
-{{#if (or (and @class.exportType @showImportPaths) this.hasToggles)}}
+{{#if (or (and @class.exportType this.showImportPaths) this.hasToggles)}}
   <Api::XMetaPanel as |panel|>
     {{#if @class.exportType}}
       <panel.header>


### PR DESCRIPTION
Fix display of import path

In v2.0.0 via https://github.com/ember-learn/ember-cli-addon-docs/pull/831/files#diff-7cd3d2b711dc840f44e1d648241f814f51ffef5405f9e4b0b474f11cebb1eb37R6, a refactor was made to use `@showImportPaths` instead of `showImportPaths`, but `showImportPaths` is not an attribute but a property from `x-class` component, see https://github.com/ember-learn/ember-cli-addon-docs/blob/master/addon/components/api/x-class/component.js#L16

___

Current behavior
![Capture d’écran 2021-09-08 à 00 59 11](https://user-images.githubusercontent.com/56396753/132421164-d8ab9c4e-a451-4e18-bde3-98bde07d0642.png)

New behavior
![Capture d’écran 2021-09-08 à 00 58 12](https://user-images.githubusercontent.com/56396753/132421175-da950b41-3429-468f-a4b4-a51d06111e97.png)

___

I really don't know if i should add some tests for this, as project is in maintenance mode and as far as i can see there is no test around that. But maybe i missed something, if you feel like we should start to add tests on these components i will add one.

___

Note that it is sure that `ember-beta` and `ember-canary` scenarios will not pass for various reasons, including this one -> 
```
liquid-fire/templates/components/liquid-outlet.hbs: Assertion Failed: Named outlets were removed in Ember 4.0. See https://deprecations.emberjs.com/v3.x#toc_route-render-template for guidance on alternative APIs for named outlet use cases. ('liquid-fire/templates/components/liquid-outlet.hbs' @ L18:C10) 
```