### PR TITLE
fix: move @glimmer/component and @glimmer/tracking in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "dependencies": {
     "@csstools/postcss-sass": "^4.0.0",
     "@ember/render-modifiers": "cibernox/ember-render-modifiers#e3574ed03409ef7a048d7716b8bea361ed6cd6e2",
+    "@glimmer/component": "^1.0.4",
+    "@glimmer/tracking": "^1.0.4",
     "@glimmer/syntax": "^0.80.0",
     "broccoli-bridge": "^1.0.0",
     "broccoli-caching-writer": "^3.0.3",
@@ -107,8 +109,6 @@
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^0.44.1",
     "@fullhuman/postcss-purgecss": "^4.0.3",
-    "@glimmer/component": "^1.0.4",
-    "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
As [@glimmer/component](https://github.com/glimmerjs/glimmer.js/tree/master/packages/%40glimmer/component) and [@glimmer/tracking](https://github.com/glimmerjs/glimmer.js/tree/master/packages/%40glimmer/tracking) are now used in the `addon` directory via this commit -> https://github.com/ember-learn/ember-cli-addon-docs/pull/934/files#diff-59d3e78aa5dff5b8d7cdf515b80e1900e1a9fc0440bb3f64a1eb98aa62af2277R1-R2

They need to be moved in dependencies, otherwise we will have this error when using v4 of this repo in an addon/app not having, for example, `@glimmer/component` in his devDeps / deps ->
```
$ ember build --environment=production
Environment: production
cleaning up...
Build Error (WebpackBundler)

ember-cli-addon-docs tried to import "@glimmer/component" in "ember-cli-addon-docs/components/docs-hero/index.js" but the package was not resolvable from /Users/nathanaeldek/Projects/ember/ember-exam/node_modules/ember-cli-addon-docs
```