### PR TITLE
fix: scss purging

### DIFF
--- a/addon/styles/components/_docs-header-search-box.scss
+++ b/addon/styles/components/_docs-header-search-box.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 input[data-search-box-input]::placeholder {
   @apply docs-text-black;
   @apply docs-font-bold;
@@ -7,3 +9,5 @@ input[data-search-box-input]::placeholder {
     @apply docs-text-grey;
   }
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/components/_docs-hero.scss
+++ b/addon/styles/components/_docs-hero.scss
@@ -1,5 +1,9 @@
+/*! purgecss start ignore */
+
 .DocsHero-background {
   height: 100vh;
   margin-top: calc(-100vh + 8rem);
   transform: skewY(-5deg);
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/components/_docs-keyboard-shortcuts.scss
+++ b/addon/styles/components/_docs-keyboard-shortcuts.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 .docs__keyboard-key {
   display: inline-block;
   padding: 3px 5px;
@@ -81,3 +83,5 @@
     text-align: left;
   }
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/components/_docs-viewer-x-current-page-index.scss
+++ b/addon/styles/components/_docs-viewer-x-current-page-index.scss
@@ -1,5 +1,9 @@
+/*! purgecss start ignore */
+
 .AddonDocs-DocsViewer-CurrentPageIndex {
   width: calc(((100% - #{$site-container}) / 2) + 14rem);
   padding-right: calc((100% - #{$site-container}) / 2);
   min-width: 14rem;
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/components/_docs-viewer-x-nav.scss
+++ b/addon/styles/components/_docs-viewer-x-nav.scss
@@ -1,6 +1,10 @@
+/*! purgecss start ignore */
+
 .AddonDocs-DocsViewer-Nav {
   @media (min-width: $site-container) {
     width: calc(((100% - #{$site-container}) / 2) + 288px);
     padding-left: calc((100% - #{$site-container}) / 2);
   }
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/components/_modal-dialog.scss
+++ b/addon/styles/components/_modal-dialog.scss
@@ -1,3 +1,7 @@
+/*! purgecss start ignore */
+
 .ember-modal-dialog {
   @apply docs-z-50;
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/tailwind/components/_docs-brand-colors.scss
+++ b/addon/styles/tailwind/components/_docs-brand-colors.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 /*
   We use CSS Custom Properties so addons can customize their brand theme, but we need to provide a fallback for browsers that don't support them yet (IE). This is the way we do it.
 
@@ -38,3 +40,5 @@
 .focus\:docs-border-brand:focus {
   @apply docs-border-brand-var;
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/tailwind/components/_docs-btn.scss
+++ b/addon/styles/tailwind/components/_docs-btn.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 .docs-btn {
   @apply docs-bg-grey-light docs-border-b-2 docs-border-grey-dark docs-py-2 docs-px-4 docs-outline-none;
 }
@@ -9,3 +11,5 @@
 .docs-btn:focus {
   @apply docs-outline-none;
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/tailwind/components/_docs-container.scss
+++ b/addon/styles/tailwind/components/_docs-container.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 .docs-container {
   @apply docs-px-4 docs-max-w-site-container docs-mx-auto;
 }
@@ -7,3 +9,5 @@
     @apply docs-px-6;
   }
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/tailwind/components/_docs-md.scss
+++ b/addon/styles/tailwind/components/_docs-md.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 .docs-md {
   -webkit-font-smoothing: antialiased;
 }
@@ -68,3 +70,5 @@
 .docs-md__hr {
   @apply docs-py-0 docs-my-8 docs-h-px docs-border-b;
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/utilities/_masks.scss
+++ b/addon/styles/utilities/_masks.scss
@@ -1,3 +1,5 @@
+/*! purgecss start ignore */
+
 /* Need to learn how to use Tailwind to generate the responsive stuff for this automatically */
 .docs-mask-image {
   /* Autoprefixer is in dependencies but not working on host apps */
@@ -23,3 +25,5 @@
     mask-image: none;
   }
 }
+
+/*! purgecss end ignore */

--- a/addon/styles/utilities/_nudge.scss
+++ b/addon/styles/utilities/_nudge.scss
@@ -1,3 +1,7 @@
+/*! purgecss start ignore */
+
 .hover\:docs-nudge-t:hover {
   transform: translateY(-1px);
 }
+
+/*! purgecss end ignore */

--- a/index.js
+++ b/index.js
@@ -251,6 +251,7 @@ module.exports = {
               : []),
           ],
           css: [styleDir],
+          safelist: ['ember-modal-dialog'],
           defaultExtractor: (content) =>
             content.match(/[A-Za-z0-9-_:/]+/g) || [],
         },

--- a/index.js
+++ b/index.js
@@ -34,27 +34,6 @@ module.exports = {
           require('tailwindcss')(
             path.join(__dirname, 'addon', 'styles', 'tailwind.config.js')
           ),
-          {
-            module: require('@fullhuman/postcss-purgecss'), // eslint-disable-line node/no-unpublished-require
-            options: {
-              content: [
-                path.join(
-                  __dirname,
-                  '{addon,app,tests/dummy/app}',
-                  '{**/,}*.{js,hbs,html,md,ts}'
-                ),
-                path.join(
-                  __dirname,
-                  'node_modules',
-                  name,
-                  'addon',
-                  '**/*.{js,hbs}'
-                ),
-              ],
-              defaultExtractor: (content) =>
-                content.match(/[A-Za-z0-9-_:/]+/g) || [],
-            },
-          },
         ],
       },
     },
@@ -248,6 +227,35 @@ module.exports = {
     importer.import('vendor/lunr/lunr.js', {
       using: [{ transformation: 'amd', as: 'lunr' }],
     });
+
+    if (EmberApp.env() === 'production') {
+      this.options['postcssOptions'].compile.plugins.push({
+        module: require('@fullhuman/postcss-purgecss'), // eslint-disable-line node/no-unpublished-require
+        options: {
+          content: [
+            path.join(
+              __dirname,
+              '{addon,app,tests/dummy/app}',
+              '{**/,}*.{js,hbs,html,md,ts}'
+            ),
+            ...(this.project.name() !== 'ember-cli-addon-docs'
+              ? [
+                  path.join(
+                    __dirname,
+                    'node_modules',
+                    name,
+                    'addon',
+                    '**/*.{js,hbs}'
+                  ),
+                ]
+              : []),
+          ],
+          css: [styleDir],
+          defaultExtractor: (content) =>
+            content.match(/[A-Za-z0-9-_:/]+/g) || [],
+        },
+      });
+    }
   },
 
   createDeployPlugin() {

--- a/index.js
+++ b/index.js
@@ -233,21 +233,9 @@ module.exports = {
         module: require('@fullhuman/postcss-purgecss'), // eslint-disable-line node/no-unpublished-require
         options: {
           content: [
-            path.join(
-              __dirname,
-              '{addon,app,tests/dummy/app}',
-              '{**/,}*.{js,hbs,html,md,ts}'
-            ),
-            ...(this.project.name() !== 'ember-cli-addon-docs'
-              ? [
-                  path.join(
-                    __dirname,
-                    'node_modules',
-                    name,
-                    'addon',
-                    '**/*.{js,hbs}'
-                  ),
-                ]
+            '{addon,app,tests/dummy/app}/{**/,}*.{js,hbs,html,md,ts}',
+            ...(this.project.name() !== name
+              ? [`node_modules/${name}/addon/{**/,}*.{js,hbs}`]
               : []),
           ],
           css: [styleDir],

--- a/index.js
+++ b/index.js
@@ -251,7 +251,6 @@ module.exports = {
               : []),
           ],
           css: [styleDir],
-          safelist: ['ember-modal-dialog'],
           defaultExtractor: (content) =>
             content.match(/[A-Za-z0-9-_:/]+/g) || [],
         },

--- a/index.js
+++ b/index.js
@@ -11,9 +11,10 @@ const walkSync = require('walk-sync');
 
 const LATEST_VERSION_NAME = '-latest';
 const styleDir = path.join(__dirname, 'addon', 'styles');
+const name = require('./package').name;
 
 module.exports = {
-  name: require('./package').name,
+  name,
 
   LATEST_VERSION_NAME,
 
@@ -33,6 +34,27 @@ module.exports = {
           require('tailwindcss')(
             path.join(__dirname, 'addon', 'styles', 'tailwind.config.js')
           ),
+          {
+            module: require('@fullhuman/postcss-purgecss'), // eslint-disable-line node/no-unpublished-require
+            options: {
+              content: [
+                path.join(
+                  __dirname,
+                  '{addon,app,tests/dummy/app}',
+                  '{**/,}*.{js,hbs,html,md,ts}'
+                ),
+                path.join(
+                  __dirname,
+                  'node_modules',
+                  name,
+                  'addon',
+                  '**/*.{js,hbs}'
+                ),
+              ],
+              defaultExtractor: (content) =>
+                content.match(/[A-Za-z0-9-_:/]+/g) || [],
+            },
+          },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@csstools/postcss-sass": "^4.0.0",
     "@ember/render-modifiers": "cibernox/ember-render-modifiers#e3574ed03409ef7a048d7716b8bea361ed6cd6e2",
+    "@fullhuman/postcss-purgecss": "^4.0.3",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@glimmer/syntax": "^0.80.0",
@@ -108,7 +109,6 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^0.44.1",
-    "@fullhuman/postcss-purgecss": "^4.0.3",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
Fix scss purging, enabling it on production build only for both ember-cli-addon-docs and project consuming this addon ; also moved https://github.com/FullHuman/purgecss/tree/main/packages/postcss-purgecss to dependencies as it is now used in the `index.js`

On [ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs) (left before, right after)
<img width="1402" alt="purcecss-ember-cli-addon-docs" src="https://user-images.githubusercontent.com/56396753/135132818-74bb7bb0-a353-4188-9f65-de9115c90801.png">

On [ember-exam](https://github.com/ember-cli/ember-exam/) (left before, right after)
![purgecss-ember-exam](https://user-images.githubusercontent.com/56396753/135132917-47afc3e3-0761-4508-9dbd-282b452e2620.png)

On [hex](https://github.com/mupkoo/hex) (a UI framework, docs made with Ember ; left before, right after)
![purgecss-hex](https://user-images.githubusercontent.com/56396753/135133006-21eaac29-09d7-4372-be8c-37adc5efc067.png)

___

Tested locally enabling it in dev. environment, saw no regression on both this addon and `ember-exam` docs (edit and no regression anymore on `hex`)

___

Todo
- check on one or two other projects using this addon
  - [x] test on https://github.com/mupkoo/hex
    - ~~some issue with `docs-md__1` classes deleted from vendors.css. If i understand well we automatically convert `# title` to `<h1 class="docs-md__1">`, so `docs-md__1` is not explicitly present in some js/hbs files and purgescss can't find it, so it delete it. I believe that we could add `/*! purgecss start ignore */` to `styles/tailwind/components/_docs-md.scss` file which will solve the issue, but need to better understand the behavior~~ -> in the end added `/*! purgecss start ignore */` to all our custom styles, to prevent similar / unwanted issues (in all case it don't have an huge impact on output file size to keep these custom styles)
     