### PR TITLE
Fixes broken deployment with ember-auto-import@2

### DIFF
--- a/blueprints/ember-cli-addon-docs/index.js
+++ b/blueprints/ember-cli-addon-docs/index.js
@@ -33,14 +33,14 @@ module.exports = {
         [
           '$&',
           '$1  // Allow ember-cli-addon-docs to update the rootURL in compiled assets',
-          "$1  ENV.rootURL = 'ADDON_DOCS_ROOT_URL';",
+          "$1  ENV.rootURL = '/ADDON_DOCS_ROOT_URL/';",
         ].join('\n')
       );
 
       if (configContents.indexOf('ADDON_DOCS_ROOT_URL') === -1) {
         this.ui.writeWarnLine(
           `Unable to update rootURL configuration. You should update ${configPath} so that your rootURL is ` +
-            `the string 'ADDON_DOCS_ROOT_URL' in production.`
+            `the string '/ADDON_DOCS_ROOT_URL/' in production.`
         );
       }
     }


### PR DESCRIPTION
When using ember-auto-import@2, it will use the `rootURL` to prefix the URLs of the injected chunks. It does this without adding a preceding slash, which means the URLs are invalid and chunks cannot be loaded. As a result, required dependencies, such as highlight.js, are not available (since they weren't loaded by the preceding chunk).