### PR TITLE
chore(deps): drop ember-href-to

### DIFF
--- a/addon/services/docs-routes.js
+++ b/addon/services/docs-routes.js
@@ -1,7 +1,6 @@
 import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import Service, { inject as service } from '@ember/service';
-import { hrefTo } from 'ember-href-to/helpers/href-to';
 import { assert } from '@ember/debug';
 
 export default Service.extend({
@@ -29,8 +28,8 @@ export default Service.extend({
   }),
 
   routeUrls: computed('routes.[]', function () {
-    return this.routes.map((route) => {
-      return hrefTo(this.router, route);
+    return this.routes.map(([routeName, model]) => {
+      return this.router.generateURL(routeName, model ? [model] : []);
     });
   }),
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "ember-decorators": "^6.1.1",
     "ember-fetch": "^8.1.1",
     "ember-get-config": "^0.3.0",
-    "ember-href-to": "^4.0.0",
     "ember-keyboard": "^6.0.3",
     "ember-modal-dialog": "yapplabs/ember-modal-dialog#76b74f1c4b791fed5b084836c3b1c8c54836ac71",
     "ember-responsive": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,9 +5948,10 @@ ember-classy-page-object@rwwagner90/ember-classy-page-object#08d305c1cabdb8ede09
   version "0.6.1"
   resolved "https://codeload.github.com/rwwagner90/ember-classy-page-object/tar.gz/08d305c1cabdb8ede091c4fc7fee86dc4778746d"
   dependencies:
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^7.12.0"
-    ember-cli-page-object "^1.17.6"
+    broccoli-funnel "^3.0.8"
+    ember-cli-babel "^7.21.0"
+    ember-cli-htmlbars "^5.2.0"
+    ember-cli-page-object "^1.17.7"
 
 ember-cli-addon-docs-yuidoc@^1.0.0:
   version "1.0.0"
@@ -6666,13 +6667,6 @@ ember-getowner-polyfill@^2.2.0:
   dependencies:
     ember-cli-version-checker "^2.1.0"
     ember-factory-for-polyfill "^1.3.1"
-
-ember-href-to@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ember-href-to/-/ember-href-to-4.1.0.tgz#daa8b398bc5a51ba3ba5ff736e099f0a0d010b7b"
-  integrity sha512-h8xSzt9lQAUzk4JvXNnZjRj29hOWKo92VIHzH68io13UurDBaMmJ4WtXa0iy/awlSFs6h8BwpEWQeaCYIZDRuQ==
-  dependencies:
-    ember-cli-babel "^7.13.2"
 
 "ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0", ember-inflector@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Reason being that it imports `@ember/routing/link-component` which has been removed in ember v4.

Replaces the helper function from this addon with a direct call to the routing service.