### PR TITLE
Set default CI config blueprints to run all builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -85,7 +85,7 @@ jobs:
     name: Test compatibility
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         scenario:
           - 'ember-lts-3.20'


### PR DESCRIPTION
This will help fixing CI so we can have all the issues available and work on them in parallel rather than via try and fail approach