### PR TITLE
PR to speed up CI times on GitHub Actions by caching dependencies.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,9 +19,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -45,9 +46,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --no-lockfile --non-interactive
@@ -71,9 +73,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -103,9 +106,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -135,9 +139,10 @@ jobs:
             "$(git config --local --get http.https://github.com/.extraheader)"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
References:
* https://github.com/actions/setup-node#caching-packages-dependencies
* https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/files/.github/workflows/ci.yml

the change is to use `actions/setup-node@v2` with `cache: yarn` option