### PR TITLE
Add babel.config.js to .npmignore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
         './lib/**/*.js',
         './tests/dummy/config/**/*.js',
         './tests-node/**/*.js',
+        'babel.config.js',
       ],
       parserOptions: {
         sourceType: 'script',

--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,7 @@
 /bower.json.ember-try
 /package.json.ember-try
 /test-apps
+
+# TODO: should be removed (so that it is included!) once
+# https://github.com/ember-modifier/ember-modifier/issues/102 is resolved
+/babel.config.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,9 @@
-/* eslint-env node */
+// TODO: this is currently only being used by ESLint via @babel/eslint-parser.
+// When https://github.com/babel/ember-cli-babel/issues/418 gets resolved,
+// we can switch to using it throughout properly.
+
+const { buildEmberPlugins } = require('ember-cli-babel');
 
 module.exports = {
-  plugins: [
-    [
-      require('@babel/plugin-proposal-decorators').default,
-      {
-        legacy: true,
-      },
-    ],
-  ],
+  plugins: [...buildEmberPlugins(__dirname)],
 };

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "yuidocjs": "^0.10.2"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.16.0",
-    "@babel/plugin-proposal-decorators": "^7.16.0",
+    "@babel/eslint-parser": "^7.16.3",
+    "@babel/preset-env": "^7.16.4",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^0.47.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,7 +35,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.16.0":
+"@babel/eslint-parser@^7.16.3":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz#2a6b1702f3f5aea48e00cea5a5bcc241c437e459"
   integrity sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==
@@ -307,7 +307,7 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
-"@babel/plugin-proposal-decorators@^7.13.5", "@babel/plugin-proposal-decorators@^7.16.0":
+"@babel/plugin-proposal-decorators@^7.13.5":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.16.4.tgz#9b35ce0716425a93b978e79099e5f7ba217c1364"
   integrity sha512-RESBNX16eNqnBeEVR5sCJpnW0mHiNLNNvGA8PrRuK/4ZJ4TO+6bHleRUuGQYDERVySOKtOhSya/C4MIhwAMAgg==
@@ -840,7 +840,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.4"
 
-"@babel/preset-env@^7.10.2", "@babel/preset-env@^7.12.0":
+"@babel/preset-env@^7.10.2", "@babel/preset-env@^7.12.0", "@babel/preset-env@^7.16.4":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.4.tgz#4f6ec33b2a3fe72d6bfdcdf3859500232563a2e3"
   integrity sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==


### PR DESCRIPTION
Follow up to #1010.

I may be wrong, followed https://github.com/babel/ember-cli-babel/issues/418, https://github.com/ember-modifier/ember-modifier/issues/102 and https://github.com/ember-modifier/ember-modifier/pull/101/files

My assumption is that addons should not ship `babel.config.js` (at least yet).

Also followed what Chris did with `buildEmberPlugins()` instead of specifying only `@babel/plugin-proposal-decorators` plugin, I assume it just gives us some sort of safety net and be on pair with ember-cli-babel (at least from babel config perspective)