### PR TITLE
Fix no implicit this deprecation in docs-demo component

### DIFF
--- a/addon/components/docs-demo/index.hbs
+++ b/addon/components/docs-demo/index.hbs
@@ -1,4 +1,4 @@
-<div class="docs-rounded docs-border docs-border-grey-lighter docs-my-8 {{class}}">
+<div class="docs-rounded docs-border docs-border-grey-lighter docs-my-8 {{this.class}}">
 
   {{yield (hash
     example=(component "docs-demo/x-example")

--- a/addon/components/docs-demo/index.hbs
+++ b/addon/components/docs-demo/index.hbs
@@ -1,4 +1,4 @@
-<div class="docs-rounded docs-border docs-border-grey-lighter docs-my-8 {{this.class}}">
+<div class="docs-rounded docs-border docs-border-grey-lighter docs-my-8 {{@class}}">
 
   {{yield (hash
     example=(component "docs-demo/x-example")


### PR DESCRIPTION
There was a missing `this` in the DocsDemo component making it fail to compile with ember-source v4+.