### PR TITLE
fix(config): use runtime config instead of embroider generated one

### DIFF
--- a/addon/adapters/-addon-docs.js
+++ b/addon/adapters/-addon-docs.js
@@ -1,10 +1,15 @@
+import { getOwner } from '@ember/application';
 import Adapter from '@ember-data/adapter';
-import config from 'ember-get-config';
 import fetch from 'fetch';
 
 export default class AddonDocsAdapter extends Adapter {
   defaultSerializer = '-addon-docs';
-  namespace = `${config.rootURL.replace(/\/$/, '')}/docs`;
+
+  get namespace() {
+    const rootURL =
+      getOwner(this).resolveRegistration('config:environment').rootURL;
+    return `${rootURL.replace(/\/$/, '')}/docs`;
+  }
 
   shouldBackgroundReloadAll() {
     return false;


### PR DESCRIPTION
Without this fix, addon docs deploys won't load correctly when using `ember-auto-import >= 2`. For me instead of loading versions.json from `https://ember-stereo.com/docs/ember-stereo.json` upon page load, it instead tried to load from `https://ember-stereo.com/ADDON_DOCS_ROOT_URL/docs/ember-stereo.json`