### PR TITLE
Support v2 addon format

### DIFF
--- a/tests/dummy/app/templates/docs/standalone-apps.md
+++ b/tests/dummy/app/templates/docs/standalone-apps.md
@@ -33,6 +33,18 @@ let app = new EmberApp(defaults, {
 });
 ```
 
+If the addon is authored in v2 Addon Format `ember-cli-addon-docs` will look for the addon source code in `src` folder.
+You may need to set `addonSrcFolder` config option if addon uses another folder:
+
+```js
+let app = new EmberApp(defaults, {
+  'ember-cli-addon-docs': {
+    documentingAddonAt: '../addon',
+    addonSrcFolder: 'source',
+  }
+});
+```
+
 At this point you should be able to run the docs app and it should look the same as if you had just added ember-cli-addon-docs for the first time to your addon.
 
 ## 6. Move all the things


### PR DESCRIPTION
The `src` folder is a the new convention for the location of the addon source code.

This can be seen in [Porting an Addon to V2](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md) guide as well as part of [new addon blueprint](https://github.com/embroider-build/addon-blueprint/tree/main/files/packages/__name__).

This was tested in https://github.com/ember-animation/ember-animated/pull/397