### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true  
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: 14
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -48,10 +48,10 @@ jobs:
     timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -75,10 +75,10 @@ jobs:
     timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -108,10 +108,10 @@ jobs:
     timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -131,7 +131,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Git user
         run: |
@@ -144,7 +144,7 @@ jobs:
             "$(git config --local --get http.https://github.com/.extraheader)"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 The original maintainers of AddonDocs have moved on, but this addon is still very much actively maintained and is still being used by many addons.
 We are currently working on embroider and fastboot support, and would love help, if anyone would like to help out!

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "ember-fetch": "^8.1.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-apps/new-addon/package.json
+++ b/test-apps/new-addon/package.json
@@ -56,15 +56,12 @@
     "webpack": "*"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  },
-  "ember": {
-    "edition": "octane"
   }
 }


### PR DESCRIPTION
`ember-cli-postcss` is listed in `dependencies` of this addon.

#1093 bumped `ember-cli-postcss` from 7.2.0 to 8.0.0 which is breaking change as 8.0.0 dropped support for Node.js 12.
Because of that, using `master` branch of `ember-cli-addon-docs` already requires Node.js 14 so this PR updates references to v12 so it also will be part of changelog.