### PR TITLE
avoid using `this.set` (fixes #1275)

### DIFF
--- a/addon/components/docs-keyboard-shortcuts/index.js
+++ b/addon/components/docs-keyboard-shortcuts/index.js
@@ -22,9 +22,9 @@ export default class DocsKeyboardShortcutsComponent extends Component {
   @onKey('KeyG', { event: 'keyup' })
   goto() {
     if (!formElementHasFocus()) {
-      this.set('isGoingTo', true);
+      this.isGoingTo = true;
       later(() => {
-        this.set('isGoingTo', false);
+        this.isGoingTo = false;
       }, 500);
     }
   }


### PR DESCRIPTION
Right now, the DocsKeyboardShortcutsComponent attempts to use `this.set`
to set a property. DocsKeyboardShortcutsComponent is a Glimmer
Component, so this API is not available.  To avoid the problem, let's
use a regular assignment statement.