### PR TITLE
Add ember-tether to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-router-scroll": "^4.1.2",
     "ember-set-helper": "^2.0.1",
     "ember-svg-jar": "^2.4.4",
+    "ember-tether": "^3.0.0",
     "ember-truth-helpers": "^3.0.0",
     "esm": "^3.2.25",
     "execa": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,7 +1269,7 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/render-modifiers@^2.0.0":
+"@ember/render-modifiers@^2.0.0", "@ember/render-modifiers@^2.0.5":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz#f4fff95a8b5cfbe947ec46644732d511711c5bf9"
   integrity sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==
@@ -7170,6 +7170,17 @@ ember-test-selectors@^6.0.0:
     calculate-cache-key-for-tree "^2.0.0"
     ember-cli-babel "^7.26.4"
     ember-cli-version-checker "^5.1.2"
+
+ember-tether@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-tether/-/ember-tether-3.0.0.tgz#a308c494a357a0d3d4133f15e44a66f9891061a0"
+  integrity sha512-2hrwbxGUuMtX4wnBJ2fYH0nx1utBM5r+g4zd7uvaqlPS3oTmTt96BKB7Xwq4R6jj6Vyxs9E48Fjv+pEAKEObnw==
+  dependencies:
+    "@ember/render-modifiers" "^2.0.5"
+    ember-auto-import "^2.6.3"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.2.0"
+    tether "^2.0.0"
 
 ember-truth-helpers@^3.0.0:
   version "3.1.1"
@@ -14669,6 +14680,11 @@ testem@^3.10.1:
     styled_string "0.0.1"
     tap-parser "^7.0.0"
     tmp "0.0.33"
+
+tether@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tether/-/tether-2.0.0.tgz#8ccb03992e71e2e913e6b1d4feb6be8cb49a4f79"
+  integrity sha512-iAkyBhwILpLIvkwzO5w5WUBtpYwxvzLRTO+sbzF3Uy7X4zznsy73v2b4sOQHXE3CQHeSNtB/YMU2Nn9tocbeBQ==
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This adds `ember-tether` to the package "depencencies" and will fix #1484.