### PR TITLE
Forward @class argument in `docs-viewer/x-nav-list` component

### DIFF
--- a/addon/components/docs-viewer/x-nav-list/index.hbs
+++ b/addon/components/docs-viewer/x-nav-list/index.hbs
@@ -1,3 +1,3 @@
-<ul ...attributes>
+<ul class={{@class}} ...attributes>
   {{yield (hash item=(component "docs-viewer/x-nav-item"))}}
 </ul>


### PR DESCRIPTION
noticed an issue while was working on `ember-cli-mirage`.

See https://www.ember-cli-mirage.com/versions/master/docs/api/modules/ember-cli-mirage/serializers/ember-data-serializer for reproduction - note "API Reference" > "ember-cli-mirage" > "Modules" > " serializers" is not indented properly as it should be on the same level as "ember-cli-mirage".

this was missed when `docs-viewer/x-nav-list` component was converted from `@ember/component` to `@glimmer/component` and previously `class` argument was assigned to the component container element and now just got lost.

the `class` argument passed in https://github.com/ember-learn/ember-cli-addon-docs/blob/v6.0.1/addon/components/docs-viewer/x-nav/index.hbs#L33