### PR TITLE
Fixed typo in <DocsViewer::XNav>

### DIFF
--- a/addon/components/docs-viewer/x-nav/index.hbs
+++ b/addon/components/docs-viewer/x-nav/index.hbs
@@ -19,8 +19,10 @@
     <div class="docs-pt-px docs-mb-8 docs-px-3 md:docs-px-4 md:docs-max-h-screen md:docs-overflow-y-scroll">
       {{#if this.media.isMobile}}
         <div class="absolute top-0 docs-text-right right-4">
-          <button {{on "click" (set this "isShowingMenu" false)}}>
-            class="docs-text-grey-darkest docs-opacity-50 hover:docs-opacity-100 docs-text-large-5 docs-py-2 docs-no-underline">
+          <button
+            class="docs-text-grey-darkest docs-opacity-50 hover:docs-opacity-100 docs-text-large-5 docs-py-2 docs-no-underline"
+            {{on "click" (set this "isShowingMenu" false)}}
+          >
             &times;
           </button>
         </div>


### PR DESCRIPTION
## Description

On mobile, the navigation shows the class names because the `<button>` tag hadn't been closed correctly.

<img width="900" alt="" src="https://github.com/ember-learn/ember-cli-addon-docs/assets/16869656/e597ea9b-5368-4ae3-99b5-2de3c68c9620">
