### PR TITLE
Fix @ember/string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
+    "@ember/string": "^3.1.1 || ^4.0.0",
     "ember-data": ">= 3.0.0",
     "ember-fetch": "^8.1.1",
     "ember-source": ">= 4.0.0"


### PR DESCRIPTION
`@ember/string` must be a dependency as `ember-cli-addon-docs` imports it in their codebase. Currently this still works, but with v4 of `@ember/string` (v2 addon) this will break as it fully relies on `ember-auto-import`.