### PR TITLE
fix: Remove ember-cli-string-helpers

### DIFF
--- a/addon/helpers/capitalize.js
+++ b/addon/helpers/capitalize.js
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import { capitalize } from '@ember/string';
+
+export default helper(function capitalizeHelper(positional) {
+  return capitalize(positional[0]);
+});

--- a/app/helpers/capitalize.js
+++ b/app/helpers/capitalize.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-addon-docs/helpers/capitalize';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-cli-clipboard": "^1.2.1",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-postcss": "^8.2.0",
-    "ember-cli-string-helpers": "^6.1.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-version-checker": "^5.1.2",
     "ember-code-snippet": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       ember-cli-postcss:
         specifier: ^8.2.0
         version: 8.2.0
-      ember-cli-string-helpers:
-        specifier: ^6.1.0
-        version: 6.1.0
       ember-cli-string-utils:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3953,10 +3950,6 @@ packages:
   ember-cli-sri@2.1.1:
     resolution: {integrity: sha512-YG/lojDxkur9Bnskt7xB6gUOtJ6aPl/+JyGYm9HNDk3GECVHB3SMN3rlGhDKHa1ndS5NK2W2TSLb9bzRbGlMdg==}
     engines: {node: '>= 0.10.0'}
-
-  ember-cli-string-helpers@6.1.0:
-    resolution: {integrity: sha512-Lw8B6MJx2n8CNF2TSIKs+hWLw0FqSYjr2/NRPyquyYA05qsl137WJSYW3ZqTsLgoinHat0DGF2qaCXocLhLmyA==}
-    engines: {node: 10.* || >=12.*}
 
   ember-cli-string-utils@1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
@@ -13474,15 +13467,6 @@ snapshots:
   ember-cli-sri@2.1.1:
     dependencies:
       broccoli-sri-hash: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-cli-string-helpers@6.1.0:
-    dependencies:
-      '@babel/core': 7.26.0
-      broccoli-funnel: 3.0.8
-      ember-cli-babel: 7.26.11
-      resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -39,6 +39,10 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    ENV['ember-tether'] = {
+      bodyElementId: 'ember-testing',
+    };
   }
 
   if (environment === 'production') {

--- a/tests/integration/helpers/capitalize-test.js
+++ b/tests/integration/helpers/capitalize-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { capitalize } from '@ember/string';
+
+module('Integration | Helper | capitalize', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    const testString = 'abc 123 ABC !@# Foo Bar';
+    this.set('inputValue', testString);
+
+    await render(hbs`{{capitalize this.inputValue}}`);
+
+    assert.dom().hasText(capitalize(testString));
+  });
+});


### PR DESCRIPTION
## Core
- This pulls @ember/string 3.1.1 into dependent project and that causes a lot of issues
- Since we have `capitalize` in @ember/string, we can just call that in our internal helper
- ~~Also bumped internal version of @ember/string to v4.x~~ -> I could not make it work, next step

## Fixed tests
- Also pins portal target for ember-tether to correct scope for testing so that assertions can work correctly

Fixes #1666